### PR TITLE
feat: implement robust server-side pagination across the stack

### DIFF
--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Post, Delete, Body, Param, Version, UseGuards, Query }
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
-import type { UserResponse } from '@enterprise/api-contracts';
+import type { UserPaginationResponse } from '@enterprise/api-contracts';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 
 @ApiTags('Users')
@@ -26,16 +26,17 @@ export class UsersController {
   @Version('1')
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'List all users' })
+  @ApiParam({ name: 'search', description: 'Search term for filtering users' })
+  @ApiParam({ name: 'page', description: 'The page number' })
+  @ApiParam({ name: 'limit', description: 'The number of users per page' })
   @ApiResponse({ status: 200, description: 'Users retrieved successfully.' })
   @Get()
-  async findAll(@Query('search') search?: string): Promise<UserResponse[]> {
-    const users = await this.usersService.findAll(search);
-    return users.map((user) => ({
-      id: user.id,
-      email: user.email,
-      role: user.role as 'admin' | 'user',
-      created: user.created.toISOString(),
-    }));
+  async findAll(
+    @Query('search') search?: string,
+    @Query('page') page: number = 1,
+    @Query('limit') limit: number = 10,
+  ): Promise<UserPaginationResponse> {
+    return this.usersService.findAll(search, Number(page), Number(limit));
   }
 
   @Version('1')

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -26,26 +26,34 @@ export class UsersService {
     });
   }
 
-  async findAll(search?: string) {
-    if (process.env.NODE_ENV === 'development') {
-      await new Promise(resolve => setTimeout(resolve, 1500));
-    }
+  async findAll(search?: string, page = 1, limit = 10) {
+    const skip = (page - 1) * limit;
 
-    return this.prisma.user.findMany({
-      where: search ? {
-            email: {
-              contains: search,
-              mode: 'insensitive',
-            },
-      } : {},
-      select: {
-        id: true,
-        email: true,
-        role: true,
-        created: true,
-      },
-      orderBy: { created: 'desc' },
-    });
+    const [items, total] = await Promise.all([
+      this.prisma.user.findMany({
+        where: search
+          ? { email: { contains: search, mode: 'insensitive' } }
+          : {},
+        select: { id: true, email: true, role: true, created: true },
+        take: limit,
+        skip: skip,
+        orderBy: { created: 'desc' },
+      }),
+      this.prisma.user.count({
+        where: search
+          ? { email: { contains: search, mode: 'insensitive' } }
+          : {},
+      }),
+    ]);
+
+    const users = items.map((user) => ({
+      id: user.id,
+      email: user.email,
+      role: user.role as 'admin' | 'user',
+      created: user.created.toISOString(),
+    }));
+
+    return { items: users, total, pages: Math.ceil(total / limit), currentPage: page };
   }
 
   async findOne(id: string) {

--- a/apps/web/app/components/AppPagination.vue
+++ b/apps/web/app/components/AppPagination.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="mt-6 flex items-center justify-between border-t border-slate-200 pt-6">
+    <div class="hidden sm:block">
+      <p class="text-sm text-slate-500 italic">
+        Showing page <span class="font-semibold text-slate-700">{{ currentPage }}</span>
+        of <span class="font-semibold text-slate-700">{{ totalPages }}</span>
+        ({{ totalItems }} total {{ type }})
+      </p>
+    </div>
+
+    <div class="flex flex-1 justify-between sm:justify-end gap-3">
+      <AppButton variant="ghost" :disabled="currentPage <= 1 || loading"
+        @click="$emit('change', currentPage - 1)">
+        <Icon name="heroicons:chevron-left" class="w-4 h-4 mr-1" />
+        Previous
+      </AppButton>
+
+      <AppButton variant="ghost" :disabled="currentPage >= totalPages || loading"
+        @click="$emit('change', currentPage + 1)">
+        Next
+        <Icon name="heroicons:chevron-right" class="w-4 h-4 ml-1" />
+      </AppButton>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  defineProps < {
+    type: string,
+    currentPage: number,
+    totalPages: number,
+    totalItems: number,
+    loading?: boolean
+  } > ()
+
+  defineEmits < {
+  (e: 'change', page: number): void
+}> ()
+</script>

--- a/apps/web/app/composables/useUsers.ts
+++ b/apps/web/app/composables/useUsers.ts
@@ -1,17 +1,19 @@
-import type { UserResponse, CreateUserDto, ActionResponse } from '@enterprise/api-contracts'
+import type { UserPaginationResponse, CreateUserDto, ActionResponse } from '@enterprise/api-contracts'
 
 export const useUsers = () => {
   const config = useRuntimeConfig()
   const apiBase = config.public.apiBase
 
   // List users
-  const fetchUsers = (search?: () => string) => {
-    return useFetch<UserResponse[]>('/users', {
+  const fetchUsers = (search?: () => string, page?: Ref<number>) => {
+    return useFetch<UserPaginationResponse>('/users', {
       baseURL: config.public.apiBase,
       query: computed(() => ({
-        search: search ? search() : undefined
+        search: search ? search() : undefined,
+        page: page?.value || 1,
+        limit: 10
       })),
-      watch: false
+      watch: [page]
     })
   }
 

--- a/apps/web/app/pages/users.vue
+++ b/apps/web/app/pages/users.vue
@@ -49,6 +49,10 @@
       <p v-if="errorMessage" class="mt-2 text-sm text-red-600">{{ errorMessage }}</p>
     </div>
 
+    <!-- Pagination -->
+    <AppPagination v-if="data?.items.length" :type="'users'" :current-page="page" :total-pages="data.pages" :total-items="data.total"
+      :loading="pending" @change="(newPage) => page = newPage" />
+
     <!-- User List Table -->
     <div class="bg-white shadow-sm border border-gray-200 rounded-xl overflow-hidden">
       <table :class="{ 'opacity-50': pending }" class="w-full text-left">
@@ -61,8 +65,8 @@
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200">
-          <template v-if="users?.length > 0">
-            <tr v-for="user in users" :key="user.id" class="hover:bg-gray-50 transition">
+          <template v-if="data?.items.length > 0">
+            <tr v-for="user in data?.items" :key="user.id" class="hover:bg-gray-50 transition">
               <td class="px-6 py-4 text-sm text-gray-900">{{ user.email }}</td>
               <td class="px-6 py-4">
                 <span
@@ -118,6 +122,10 @@
       </table>
     </div>
 
+    <!-- Pagination -->
+    <AppPagination v-if="data?.items.length" :type="'users'" :current-page="page" :total-pages="data.pages"
+      :total-items="data.total" :loading="pending" @change="(newPage) => page = newPage" />
+
     <!-- Deletion Confirmation Modal -->
     <AppModal v-model="isModalOpen">
       <template #icon>
@@ -148,6 +156,7 @@
 
 <script setup lang="ts">
   const searchTerm = ref('')
+  const page = ref(1)
 
   const roleStyles = {
     admin: 'bg-indigo-100 text-indigo-700 border-indigo-200',
@@ -156,11 +165,13 @@
   
   const { addToast } = useToast()
   const { fetchUsers, createUser } = useUsers()
-  const { data: users, refresh, pending } = await fetchUsers(() => searchTerm.value)
+  
+  const { data, refresh, pending } = await fetchUsers(() => searchTerm.value, page)
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
   watch(searchTerm, (newValue) => {
+    page.value = 1
     if (debounceTimer) clearTimeout(debounceTimer)
     debounceTimer = setTimeout(async () => {
       const result = await refresh()

--- a/packages/api-contracts/index.ts
+++ b/packages/api-contracts/index.ts
@@ -1,3 +1,11 @@
+// Shared interface for any paginated respoonse
+export interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  pages: number;
+  currentPage: number;
+}
+
 // Shared interface for User data
 export interface UserResponse {
   id: string;
@@ -5,6 +13,9 @@ export interface UserResponse {
   role: 'admin' | 'user';
   created: string;
 }
+
+// Shared interface for User data with pagination
+export type UserPaginationResponse = PaginatedResponse<UserResponse>;
 
 // Shared interface for API error responses
 export interface ApiError {


### PR DESCRIPTION
## 🎯 Description
Implemented server-side pagination for the User Management table to improve performance and scalability.

## 🛠 Changes
- **Backend:** Updated `UsersService` to support `skip` and `take` via Prisma.
- **Backend:** Integrated total count metadata in the API response.
- **Frontend:** Added pagination controls to the Users page.
- **Frontend:** Updated `useUsers` composable to handle paged requests.

## 🧪 How to test
1. Run `pnpm --filter @enterprise/database db:seed` to ensure 50+ users exist.
2. Navigate to `/users`.
3. Verify that only 10 users are displayed per page.
4. Test the "Next" and "Previous" buttons.
