### PR TITLE
Feat/i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A professional showcase of a high-performance distributed system architecture. T
 - **Type Safety:** Shared API Contracts (`@enterprise/api-contracts`) providing End-to-End type safety between Backend and Frontend.
 - **Security:** JWT Authentication, Bcrypt hashing, and Rate Limiting (Throttler).
 - **Quality Assurance:** [Vitest](https://vitest.dev/) for Unit/Component testing & [Swagger](https://swagger.io/) for OpenAPI docs.
+- **Internationalization:** @nuxtjs/i18n with Lazy-loading and SEO-friendly prefix strategy
 - **Observability:** Structured JSON Logging with [Pino](https://getpino.io).
 - **Infrastructure:** Dockerised environment (PostgreSQL, Adminer) for seamless onboarding.
 
@@ -28,6 +29,10 @@ A professional showcase of a high-performance distributed system architecture. T
 - **Resilient API:** Global ValidationPipes, ThrottlerGuards for brute-force protection, and Multi-stage Docker builds.
 - **CI/CD Pipeline:** Automated GitHub Actions for Build, Lint, and Test (Backend & Frontend) with pnpm caching.
 - **Environment Robustness:** Centralised `.env` management with variable expansion (DRY principle) and Turborepo injection.
+- **Dynamic Multi-language Support:** Full localization (en-GB, pt-BR, es-ES) with real-time switching for UI, charts (Chart.js), and data formatting.
+- **Stateful Navigation:** Search terms and pagination states are persisted across language changes using URL query synchronization.
+- **Locale-Aware Middleware:** Automated redirection and authentication flows that respect the user's preferred language, even after session termination (logout).
+- **Intl API Integration:** Native browser Intl API usage for performant and accurate date/currency formatting based on the active locale.
 
 ## 📁 Project Structure
 
@@ -61,6 +66,8 @@ Backend Docs: http://localhost:3001/docs
 > - **User:** `admin@enterprise.uk`
 > - **Password:** `admin123`
 
+> [!TIP]
+> The system is fully localized. You can switch languages directly on the Login Page or via the Dashboard Header to see the reactive UI transformation.
 
 ### 🛠 Setup & Running for Dev
 

--- a/apps/web/app/components/AppLanguageSelect.vue
+++ b/apps/web/app/components/AppLanguageSelect.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="relative flex items-center">
+    <Icon name="heroicons:language" class="absolute left-2.5 w-4 h-4 text-slate-400 pointer-events-none" />
+    <select :value="locale" @change="onLocaleChange"
+      class="appearance-none bg-slate-50 border border-slate-200 text-slate-600 text-xs font-bold rounded-lg pl-8 pr-8 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none cursor-pointer transition-all hover:bg-slate-100">
+      <option v-for="lang in locales" :key="lang.code" :value="lang.code">
+        {{ lang.code.toUpperCase() }}
+      </option>
+    </select>
+    <!-- Custom Arrow Icon -->
+    <Icon name="heroicons:chevron-down" class="absolute right-2 w-3 h-3 text-slate-400 pointer-events-none" />
+  </div>
+</template>
+
+<script setup lang="ts">
+  const { locale, locales, setLocale } = useI18n()
+
+  const onLocaleChange = (event: Event) => {
+    const target = event.target as HTMLSelectElement
+    setLocale(target.value)
+  }
+</script>

--- a/apps/web/app/components/AppPagination.vue
+++ b/apps/web/app/components/AppPagination.vue
@@ -2,9 +2,12 @@
   <div class="mt-6 flex items-center justify-between border-t border-slate-200 pt-6">
     <div class="hidden sm:block">
       <p class="text-sm text-slate-500 italic">
-        Showing page <span class="font-semibold text-slate-700">{{ currentPage }}</span>
-        of <span class="font-semibold text-slate-700">{{ totalPages }}</span>
-        ({{ totalItems }} total {{ type }})
+        {{ $t('pagination.showing', {
+        current: currentPage,
+        total: totalPages,
+        count: totalItems,
+        subject: type
+        }) }}
       </p>
     </div>
 
@@ -12,12 +15,12 @@
       <AppButton variant="ghost" :disabled="currentPage <= 1 || loading"
         @click="$emit('change', currentPage - 1)">
         <Icon name="heroicons:chevron-left" class="w-4 h-4 mr-1" />
-        Previous
+        {{ $t('pagination.previous') }}
       </AppButton>
 
       <AppButton variant="ghost" :disabled="currentPage >= totalPages || loading"
         @click="$emit('change', currentPage + 1)">
-        Next
+        {{ $t('pagination.next') }}
         <Icon name="heroicons:chevron-right" class="w-4 h-4 ml-1" />
       </AppButton>
     </div>

--- a/apps/web/app/components/DashboardChart.vue
+++ b/apps/web/app/components/DashboardChart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="bg-white p-6 rounded-xl shadow-sm border border-slate-200">
     <h3 class="text-sm font-semibold text-slate-500 uppercase tracking-wider mb-6">
-      User Distribution
+      {{ $t('charts.user_distribution') }}
     </h3>
     <div class="h-[300px]">
       <Doughnut :data="chartData" :options="chartOptions" />
@@ -13,6 +13,8 @@
   import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js'
   import { Doughnut } from 'vue-chartjs'
 
+  const { t } = useI18n()
+
   ChartJS.register(ArcElement, Tooltip, Legend)
 
   const props = defineProps < {
@@ -21,7 +23,10 @@
   } > ()
 
   const chartData = computed(() => ({
-    labels: ['Administrators', 'Regular Users'],
+    labels: [
+      t('charts.labels.admins'),
+      t('charts.labels.users')
+    ],
     datasets: [{
       backgroundColor: ['#6366f1', '#e2e8f0'],
       hoverBackgroundColor: ['#4f46e5', '#cbd5e1'],
@@ -31,7 +36,7 @@
     }]
   }))
 
-  const chartOptions = {
+  const chartOptions = computed(() => ({
     responsive: true,
     maintainAspectRatio: false,
     plugins: {
@@ -44,5 +49,5 @@
         }
       }
     }
-  }
+  }))
 </script>

--- a/apps/web/app/composables/useAuth.ts
+++ b/apps/web/app/composables/useAuth.ts
@@ -5,6 +5,7 @@ export const useAuth = () => {
   const user = useState<AuthResponse['user'] | null>('auth_user', () => null)
   const config = useRuntimeConfig()
   const localePath = useLocalePath()
+  const { $i18n } = useNuxtApp()
 
   const login = async (credentials: LoginDto) => {
     try {
@@ -19,7 +20,7 @@ export const useAuth = () => {
 
       return navigateTo(localePath('/dashboard'))
     } catch (e: any) {
-      throw e.data?.message || t('messages.login_failed')
+      throw e.data?.message || $i18n.t('messages.login_failed')
     }
   }
 

--- a/apps/web/app/composables/useAuth.ts
+++ b/apps/web/app/composables/useAuth.ts
@@ -4,6 +4,7 @@ export const useAuth = () => {
   const token = useCookie('auth_token', { maxAge: 3600, sameSite: 'lax' })
   const user = useState<AuthResponse['user'] | null>('auth_user', () => null)
   const config = useRuntimeConfig()
+  const localePath = useLocalePath()
 
   const login = async (credentials: LoginDto) => {
     try {
@@ -16,16 +17,16 @@ export const useAuth = () => {
       token.value = data.access_token
       user.value = data.user
 
-      return navigateTo('/users')
+      return navigateTo(localePath('/dashboard'))
     } catch (e: any) {
-      throw e.data?.message || 'Login failed'
+      throw e.data?.message || t('messages.login_failed')
     }
   }
 
   const logout = () => {
     token.value = null
     user.value = null
-    return navigateTo('/login')
+    return navigateTo(localePath('/login'))
   }
 
   return { token, user, login, logout, isAuthenticated: computed(() => !!token.value) }

--- a/apps/web/app/composables/useFormatters.ts
+++ b/apps/web/app/composables/useFormatters.ts
@@ -1,0 +1,15 @@
+export const useFormatters = () => {
+  const { locale } = useI18n()
+
+  const formatDate = (date: string) => {
+    return new Intl.DateTimeFormat(locale.value === 'pt' ? 'pt-BR' : locale.value === 'es' ? 'es-ES' : 'en-GB', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric'
+    }).format(new Date(date))
+  }
+
+  return {
+    formatDate
+  }
+}

--- a/apps/web/app/composables/useUsers.ts
+++ b/apps/web/app/composables/useUsers.ts
@@ -1,6 +1,7 @@
 import type { UserPaginationResponse, UserResponse, CreateUserDto, ActionResponse } from '@enterprise/api-contracts'
 
 export const useUsers = () => {
+  const { locale } = useI18n()
   const config = useRuntimeConfig()
   const apiBase = config.public.apiBase
 
@@ -11,7 +12,8 @@ export const useUsers = () => {
       query: computed(() => ({
         search: search ? search() : undefined,
         page: page?.value || 1,
-        limit: 10
+        limit: 10,
+        lang: locale.value
       })),
       watch: false
     })

--- a/apps/web/app/layouts/default.vue
+++ b/apps/web/app/layouts/default.vue
@@ -4,22 +4,22 @@
     <aside class="w-64 bg-slate-900 text-slate-300 flex flex-col fixed h-full">
       <div class="p-6 flex items-center gap-3">
         <div class="h-8 w-8 bg-indigo-500 rounded-lg flex items-center justify-center text-white font-bold">E</div>
-        <span class="text-white font-semibold text-lg tracking-tight">Enterprise</span>
+        <span class="text-white font-semibold text-lg tracking-tight">{{ $t('title') }}</span>
       </div>
 
       <nav class="flex-1 px-4 space-y-2 mt-4">
-        <NuxtLink to="/dashboard"
+        <NuxtLink :to="localePath('/dashboard')"
           class="flex items-center gap-3 px-4 py-3 rounded-lg transition-colors hover:bg-slate-800 hover:text-white"
           active-class="bg-slate-800 text-white border-l-4 border-indigo-500">
           <Icon name="heroicons:squares-2x2" class="w-5 h-5" />
-          <span class="text-sm font-medium">Dashboard Overview</span>
+          <span class="text-sm font-medium">{{ $t('dashboard') }}</span>
         </NuxtLink>
 
-        <NuxtLink to="/users"
+        <NuxtLink :to="localePath('/users')"
           class="flex items-center gap-3 px-4 py-3 rounded-lg transition-colors hover:bg-slate-800 hover:text-white"
           active-class="bg-slate-800 text-white border-l-4 border-indigo-500">
           <Icon name="heroicons:users" class="w-5 h-5" />
-          <span class="text-sm font-medium">User Management</span>
+          <span class="text-sm font-medium">{{ $t('users') }}</span>
         </NuxtLink>
       </nav>
 
@@ -28,11 +28,11 @@
         <button @click="handleLogout"
           class="flex w-full items-center gap-3 px-4 py-3 rounded-lg text-red-400 hover:bg-red-500/10 hover:text-red-300 transition-colors">
           <Icon name="heroicons:arrow-left-on-rectangle" class="w-5 h-5" />
-          <span class="text-sm font-medium">Sign Out</span>
+          <span class="text-sm font-medium">{{ $t('logout') }}</span>
         </button>
       
         <div class="mt-4 px-4 py-3 text-[10px] uppercase tracking-widest font-semibold text-slate-500">
-          UK Market v1.0
+          {{ $t('footer') }}
         </div>
       </div>
     </aside>
@@ -42,11 +42,13 @@
       <!-- Top Bar -->
       <header class="h-16 bg-white border-b border-slate-200 flex items-center justify-end px-8 sticky top-0 z-30">
         <div class="flex items-center gap-4">
-          <NuxtLink to="/profile" class="flex items-center gap-3 hover:bg-slate-50 p-2 rounded-lg transition-colors group">
+          <AppLanguageSelect />
+
+          <NuxtLink :to="localePath('/profile')" class="flex items-center gap-3 hover:bg-slate-50 p-2 rounded-lg transition-colors group">
             <div class="text-right hidden sm:block">
-              <p class="text-xs text-slate-400 font-medium uppercase tracking-wider">Account</p>
+              <p class="text-xs text-slate-400 font-medium uppercase tracking-wider">{{ $t('profile') }}</p>
               <p class="text-sm font-bold text-slate-700 group-hover:text-indigo-600 transition-colors">
-                View Profile
+                {{ $t('view_profile') }}
               </p>
             </div>
       
@@ -75,9 +77,11 @@
 <script setup lang="ts">
   const { logout } = useAuth()
   const { addToast } = useToast()
+  const { t, locale, locales, setLocale } = useI18n()
+  const localePath = useLocalePath()
 
   const handleLogout = () => {
     logout()
-    addToast('Signed out successfully. See you soon!', 'info')
+    addToast(t('messages.logout_success'), 'info')
   }
 </script>

--- a/apps/web/app/locales/en-GB.json
+++ b/apps/web/app/locales/en-GB.json
@@ -1,0 +1,121 @@
+{
+  "title": "Enterprise",
+  "welcome": "Welcome back",
+  "dashboard": "Dashboard Overview",
+  "users": "User Management",
+  "profile": "My Profile",
+  "view_profile": "View Profile",
+  "logout": "Sign Out",
+  "footer": "UK Market v1.0",
+  "pagination": {
+    "showing": "Showing page {current} of {total} ({count} total {subject})",
+    "previous": "Previous",
+    "next": "Next"
+  },
+  "messages": {
+    "login_failed": "Login failed",
+    "logout_success": "Signed out successfully. See you soon!"
+  },
+  "pages": {
+    "login": {
+      "title": "Enterprise Portal",
+      "subtitle": "Sign in to access your dashboard",
+      "email_label": "Business Email",
+      "email_placeholder": "Enter your email",
+      "password_label": "Password",
+      "sign_in": "Sign In",
+      "messages": {
+        "login_success": "Welcome back!",
+        "login_error": "Authentication failed"
+      }
+    },
+    "dashboard": {
+      "title": "System Overview",
+      "stats": {
+        "total_users": "Total Users",
+        "admins": "Administrators",
+        "latest_entry": "Latest Entry",
+        "status_live": "Live",
+        "no_users": "No users yet"
+      },
+      "recent_signups": {
+        "title": "Recent Signups",
+        "view_all": "View all"
+      }
+    },
+    "users": {
+      "type": "users",
+      "title": "User Management",
+      "add_user": "Add New User",
+      "close_form": "Close",
+      "search_placeholder": "Search by email...",
+      "clear_search": "Clear search",
+      "no_users_found": "No users found",
+      "confirm_deletion": {
+        "title": "Confirm Deletion",
+        "message": "Are you sure you want to delete this user? This action cannot be undone and will permanently remove the data from our servers.",
+        "confirm": "Delete User",
+        "cancel": "Cancel"
+      },
+      "table": {
+        "email": "Email Address",
+        "role": "Role",
+        "created_at": "Created At",
+        "actions": "Actions",
+        "delete": "Delete"
+      },
+      "form": {
+        "email_label": "Business Email",
+        "password_label": "Initial Password",
+        "role_label": "Account Role",
+        "email_placeholder": "uk-market.com",
+        "password_placeholder": "Min. 8 characters",
+        "role_user": "User",
+        "role_admin": "Administrator",
+        "submit": "Save User",
+        "submitting": "Saving...",
+        "cancel": "Cancel"
+      },
+      "messages": {
+        "success_create": "New user registered successfully",
+        "error_create": "Error creating user",
+        "success_delete": "User deleted successfully",
+        "error_delete": "Failed to delete user",
+        "no_results": "No users found matching \"{search}\""
+      }
+    },
+    "profile": {
+      "title": "Account Settings",
+      "subtitle": "Manage your personal information and security preferences.",
+      "labels": {
+        "email": "Email Address",
+        "role": "Account Role",
+        "member_since": "Member Since",
+        "status": "Status",
+        "active": "Active",
+        "unique_id": "Your unique identifier"
+      },
+      "security": {
+        "title": "Security & Privacy",
+        "description": "Authenticated sessions are managed via secure JWT tokens with 1-hour expiration, following cybersecurity standards.",
+        "change_password": "Change Password",
+        "enable_2fa": "Enable 2FA"
+      },
+      "actions": {
+        "request_changes": "Request Changes",
+        "contact_admin": "Contact your admin to change email"
+      },
+      "errors": {
+        "load_fail": "Failed to load profile data"
+      }
+    }
+  },
+  "charts": {
+    "user_distribution": "User Distribution",
+    "labels": {
+      "admins": "Administrators",
+      "users": "Regular Users"
+    }
+  },
+  "search_placeholder": "Search users..."
+}

--- a/apps/web/app/locales/es-ES.json
+++ b/apps/web/app/locales/es-ES.json
@@ -1,0 +1,121 @@
+{
+  "title": "Enterprise",
+  "welcome": "Bienvenido de nuevo",
+  "dashboard": "Vista General",
+  "users": "Gestión de Usuarios",
+  "profile": "Mi Perfil",
+  "view_profile": "Ver Perfil",
+  "logout": "Cerrar Sesión",
+  "footer": "Mercado UK v1.0",
+  "pagination": {
+    "showing": "Mostrando página {current} de {total} ({count} {subject} en total)",
+    "previous": "Anterior",
+    "next": "Siguiente"
+  },
+  "messages": {
+    "login_failed": "Error de inicio de sesión",
+    "logout_success": "Sesión cerrada con éxito. ¡Hasta pronto!"
+  },
+  "pages": {
+    "login": {
+      "title": "Portal Enterprise",
+      "subtitle": "Inicie sesión para acceder a su panel",
+      "email_label": "Email Corporativo",
+      "email_placeholder": "Digite su e-mail",
+      "password_label": "Contraseña",
+      "sign_in": "Iniciar Sesión",
+      "messages": {
+        "login_success": "¡Bienvenido de nuevo!",
+        "login_error": "Error de autenticación"
+      }
+    },
+    "dashboard": {
+      "title": "Vista General",
+      "stats": {
+        "total_users": "Total de Usuarios",
+        "admins": "Administradores",
+        "latest_entry": "Último Registro",
+        "status_live": "En Vivo",
+        "no_users": "Sin usuarios aún"
+      },
+      "recent_signups": {
+        "title": "Registros Recientes",
+        "view_all": "Ver todos"
+      }
+    },
+    "users": {
+      "type": "usuarios",
+      "title": "Gestión de Usuarios",
+      "add_user": "Añadir Nuevo Usuario",
+      "close_form": "Cerrar",
+      "search_placeholder": "Buscar por email...",
+      "clear_search": "Limpiar búsqueda",
+      "no_users_found": "No se encontraron usuarios",
+      "confirm_deletion": {
+        "title": "Confirmar Eliminación",
+        "message": "¿Estás seguro de que deseas eliminar este usuario? Esta acción no se puede deshacer y eliminará permanentemente los datos de nuestros servidores.",
+        "confirm": "Eliminar Usuario",
+        "cancel": "Cancelar"
+      },
+      "table": {
+        "email": "Correo Electrónico",
+        "role": "Rol",
+        "created_at": "Creado el",
+        "actions": "Acciones",
+        "delete": "Eliminar"
+      },
+      "form": {
+        "email_label": "Email Corporativo",
+        "password_label": "Contraseña Inicial",
+        "role_label": "Rol de la Cuenta",
+        "email_placeholder": "mercado-uk.com",
+        "password_placeholder": "Mín. 8 caracteres",
+        "role_user": "Usuario",
+        "role_admin": "Administrador",
+        "submit": "Guardar Usuario",
+        "submitting": "Guardando...",
+        "cancel": "Cancelar"
+      },
+      "messages": {
+        "success_create": "Nuevo usuario registrado con éxito",
+        "error_create": "Error al crear el usuario",
+        "success_delete": "Usuario eliminado con éxito",
+        "error_delete": "Error al eliminar el usuario",
+        "no_results": "No se encontraron usuarios que coincidan con \"{search}\""
+      }
+    },
+    "profile": {
+      "title": "Configuración de la Cuenta",
+      "subtitle": "Administre su información personal y preferencias de seguridad.",
+      "labels": {
+        "email": "Correo Electrónico",
+        "role": "Rol de la Cuenta",
+        "member_since": "Miembro desde",
+        "status": "Estado",
+        "active": "Activo",
+        "unique_id": "Su identificador único"
+      },
+      "security": {
+        "title": "Seguridad y Privacidad",
+        "description": "Las sesiones autenticadas se gestionan mediante tokens JWT seguros con caducidad de 1 hora, siguiendo los estándares de ciberseguridad.",
+        "change_password": "Cambiar Contraseña",
+        "enable_2fa": "Activar 2FA"
+      },
+      "actions": {
+        "request_changes": "Solicitar Cambios",
+        "contact_admin": "Contacte con su administrador para cambiar el email"
+      },
+      "errors": {
+        "load_fail": "Error al cargar los datos del perfil"
+      }
+    }
+  },
+  "charts": {
+    "user_distribution": "Distribución de Usuarios",
+    "labels": {
+      "admins": "Administradores",
+      "users": "Usuarios Regulares"
+    }
+  },
+  "search_placeholder": "Buscar usuarios..."
+}

--- a/apps/web/app/locales/pt-BR.json
+++ b/apps/web/app/locales/pt-BR.json
@@ -1,0 +1,121 @@
+{
+  "title": "Enterprise",
+  "welcome": "Bem-vindo de volta",
+  "dashboard": "Visão Geral",
+  "users": "Gestão de Usuários",
+  "profile": "Meu Perfil",
+  "view_profile": "Ver Perfil",
+  "logout": "Sair",
+  "footer": "UK Market v1.0",
+  "pagination": {
+    "showing": "Exibindo página {current} de {total} ({count} {subject} no total)",
+    "previous": "Anterior",
+    "next": "Próximo"
+  },
+  "messages": {
+    "login_failed": "Falha no login",
+    "logout_success": "Sessão encerrada com sucesso. Até logo!"
+  },
+  "pages": {
+    "login": {
+      "title": "Portal Enterprise",
+      "subtitle": "Faça login para acessar seu painel",
+      "email_label": "E-mail Corporativo",
+      "email_placeholder": "Digite seu e-mail",
+      "password_label": "Senha",
+      "sign_in": "Entrar",
+      "messages": {
+        "login_success": "Bem-vindo de volta!",
+        "login_error": "Falha na autenticação"
+      }
+    },
+    "dashboard": {
+      "title": "Visão Geral do Sistema",
+      "stats": {
+        "total_users": "Total de Usuários",
+        "admins": "Administradores",
+        "latest_entry": "Último Registro",
+        "status_live": "Ao vivo",
+        "no_users": "Nenhum usuário"
+      },
+      "recent_signups": {
+        "title": "Cadastros Recentes",
+        "view_all": "Ver todos"
+      }
+    },
+    "users": {
+      "type": "usuários",
+      "title": "Gestão de Usuários",
+      "add_user": "Adicionar Usuário",
+      "close_form": "Fechar",
+      "search_placeholder": "Buscar por e-mail...",
+      "clear_search": "Limpar busca",
+      "no_users_found": "Nenhum usuário encontrado",
+      "confirm_deletion": {
+        "title": "Confirmação de Exclusão",
+        "message": "Tem certeza que deseja excluir este usuário? Esta ação não pode ser desfeita e irá remover os dados de nossos servidores permanentemente.",
+        "confirm": "Excluir Usuário",
+        "cancel": "Cancelar"
+      },
+      "table": {
+        "email": "E-mail",
+        "role": "Cargo",
+        "created_at": "Criado em",
+        "actions": "Ações",
+        "delete": "Excluir"
+      },
+      "form": {
+        "email_label": "E-mail Corporativo",
+        "password_label": "Senha Inicial",
+        "role_label": "Cargo da Conta",
+        "email_placeholder": "uk-market.com",
+        "password_placeholder": "Mín. 8 caracteres",
+        "role_user": "Usuário",
+        "role_admin": "Administrador",
+        "submit": "Criar Usuário",
+        "submitting": "Criando...",
+        "cancel": "Cancelar"
+      },
+      "messages": {
+        "success_create": "Novo usuário registrado com sucesso",
+        "error_create": "Erro ao criar usuário",
+        "success_delete": "Usuário excluído com sucesso",
+        "error_delete": "Falha ao excluir usuário",
+        "no_results": "Nenhum usuário encontrado para \"{search}\""
+      }
+    },
+    "profile": {
+      "title": "Configurações da Conta",
+      "subtitle": "Gerencie suas informações pessoais e preferências de segurança.",
+      "labels": {
+        "email": "Endereço de E-mail",
+        "role": "Cargo na Conta",
+        "member_since": "Membro desde",
+        "status": "Status",
+        "active": "Ativo",
+        "unique_id": "Seu identificador único"
+      },
+      "security": {
+        "title": "Segurança & Privacidade",
+        "description": "As sessões autenticadas são gerenciadas via tokens JWT seguros com expiração de 1 hora, seguindo padrões de cibersegurança.",
+        "change_password": "Alterar Senha",
+        "enable_2fa": "Ativar 2FA"
+      },
+      "actions": {
+        "request_changes": "Solicitar Alterações",
+        "contact_admin": "Entre em contato com o administrador para alterar o e-mail"
+      },
+      "errors": {
+        "load_fail": "Falha ao carregar dados do perfil"
+      }
+    }
+  },
+  "charts": {
+    "user_distribution": "Distribuição de Usuários",
+    "labels": {
+      "admins": "Administradores",
+      "users": "Usuários Comuns"
+    }
+  },
+  "search_placeholder": "Buscar usuários..."
+}

--- a/apps/web/app/middleware/auth.global.ts
+++ b/apps/web/app/middleware/auth.global.ts
@@ -1,16 +1,17 @@
 export default defineNuxtRouteMiddleware((to) => {
+  const localePath = useLocalePath()
   const { isAuthenticated } = useAuth()
 
   // List of routes that do NOT require authentication.
-  const publicRoutes = ['/login']
+  const publicRoutes = [localePath('/login')]
 
   // If the user is not authenticated and tries to access a protected route
   if (!isAuthenticated.value && !publicRoutes.includes(to.path)) {
-    return navigateTo('/login')
+    return navigateTo(localePath('/login'))
   }
 
   // If the user is authenticated and tries to access the login page, redirect to dashboard
-  if (isAuthenticated.value && to.path === '/login') {
-    return navigateTo('/users')
+  if (isAuthenticated.value && to.path === localePath('/login')) {
+    return navigateTo(localePath('/dashboard'))
   }
 })

--- a/apps/web/app/pages/dashboard.vue
+++ b/apps/web/app/pages/dashboard.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h1 class="text-2xl font-bold text-slate-900 mb-8">System Overview</h1>
+    <h1 class="text-2xl font-bold text-slate-900 mb-8">{{ t('pages.dashboard.title') }}</h1>
 
     <div v-if="pending" class="grid grid-cols-1 md:grid-cols-3 gap-6 animate-pulse">
       <div v-for="i in 3" :key="i" class="h-32 bg-slate-200 rounded-xl"></div>
@@ -13,9 +13,9 @@
           <div class="p-2 bg-indigo-50 rounded-lg text-indigo-600">
             <Icon name="heroicons:users" class="w-6 h-6" />
           </div>
-          <span class="text-xs font-medium text-green-600 bg-green-50 px-2 py-1 rounded">Live</span>
+          <span class="text-xs font-medium text-green-600 bg-green-50 px-2 py-1 rounded">{{ t('pages.dashboard.stats.status_live') }}</span>
         </div>
-        <p class="text-sm font-medium text-slate-500">Total Users</p>
+        <p class="text-sm font-medium text-slate-500">{{ t('pages.dashboard.stats.total_users') }}</p>
         <h3 class="text-3xl font-bold text-slate-900">{{ data?.totalUsers }}</h3>
       </div>
 
@@ -26,7 +26,7 @@
             <Icon name="heroicons:shield-check" class="w-6 h-6" />
           </div>
         </div>
-        <p class="text-sm font-medium text-slate-500">Administrators</p>
+        <p class="text-sm font-medium text-slate-500">{{ t('pages.dashboard.stats.admins') }}</p>
         <h3 class="text-3xl font-bold text-slate-900">{{ data?.totalAdmins }}</h3>
       </div>
 
@@ -37,7 +37,7 @@
             <Icon name="heroicons:bolt" class="w-6 h-6" />
           </div>
         </div>
-        <p class="text-sm font-medium text-slate-500">Latest Entry</p>
+        <p class="text-sm font-medium text-slate-500">{{ t('pages.dashboard.stats.latest_entry') }}</p>
         <h3 class="text-lg font-bold text-slate-900 truncate" :title="data?.lastSignup">
           {{ data?.lastSignup }}
         </h3>
@@ -49,8 +49,8 @@
     
       <div class="bg-white border border-slate-200 rounded-xl shadow-sm">
         <div class="p-6 border-b border-slate-100 flex justify-between items-center">
-          <h3 class="font-bold text-slate-800">Recent Signups</h3>
-          <NuxtLink to="/users" class="text-sm text-indigo-600 hover:underline">View all</NuxtLink>
+          <h3 class="font-bold text-slate-800">{{ t('pages.dashboard.recent_signups.title') }}</h3>
+          <NuxtLink :to="localePath('/users')" class="text-sm text-indigo-600 hover:underline">{{ t('pages.dashboard.recent_signups.view_all') }}</NuxtLink>
         </div>
       
         <div class="overflow-x-auto">
@@ -67,7 +67,7 @@
                   </div>
                 </td>
                 <td class="px-6 py-4 text-xs text-slate-400">
-                  {{ new Date(user.created).toLocaleDateString('en-GB') }}
+                  {{ formatDate(user.created) }}
                 </td>
                 <td class="px-6 py-4 text-right">
                   <span
@@ -88,6 +88,11 @@
 <script setup lang="ts">
   const { token } = useAuth()
   const config = useRuntimeConfig()
+  const { t } = useI18n()
+  const { formatDate } = useFormatters()
+  const localePath = useLocalePath()
+
+  useHead({ title: `${t('pages.dashboard.title')} | ${t('title')}` })
 
   const { data, pending } = await useFetch < any > ('/analytics/overview', {
     baseURL: config.public.apiBase,

--- a/apps/web/app/pages/login.spec.ts
+++ b/apps/web/app/pages/login.spec.ts
@@ -7,13 +7,16 @@ describe('Login Page', () => {
   it('renders login form correctly', async () => {
     const page = await mountSuspended(Login)
     
+    expect(page.find('select').exists()).toBe(true)
+    expect(page.find('select').findAll('option').length).toBeGreaterThan(1)
+
     expect(page.find('h1').text()).toContain('Enterprise Portal')
     expect(page.find('input[type="email"]').exists()).toBe(true)
     expect(page.find('input[type="password"]').exists()).toBe(true)
     expect(page.find('button').text()).toContain('Sign In')
   })
 
-  it('shows error message on failed login', async () => {
+  it('shows localized error message on failed login', async () => {
     // Register a fake endpoint that returns 401 error
     registerEndpoint('http://localhost:3001/api/v1/auth/login', {
       method: 'POST',
@@ -39,7 +42,6 @@ describe('Login Page', () => {
     const errorMsg = page.find('[class*="text-red-600"]')
 
     expect(errorMsg.exists()).toBe(true)
-
     expect(errorMsg.text()).toContain('Login failed')
   })
 })

--- a/apps/web/app/pages/login.vue
+++ b/apps/web/app/pages/login.vue
@@ -1,32 +1,36 @@
 <template>
   <div class="min-h-screen flex items-center justify-center bg-slate-50 px-4">
+    <div class="absolute top-4 right-4 sm:top-8 sm:right-8">
+      <AppLanguageSelect />
+    </div>
+
     <div class="max-w-md w-full bg-white rounded-2xl shadow-xl p-8 border border-slate-100">
       <div class="text-center mb-8">
         <div
           class="inline-flex items-center justify-center w-16 h-16 bg-indigo-600 rounded-xl mb-4 shadow-lg shadow-indigo-200">
           <Icon name="heroicons:lock-closed" class="w-8 h-8 text-white" />
         </div>
-        <h1 class="text-2xl font-bold text-slate-900">Enterprise Portal</h1>
-        <p class="text-slate-500 text-sm mt-2">Sign in to access your dashboard</p>
+        <h1 class="text-2xl font-bold text-slate-900">{{ t('pages.login.title') }}</h1>
+        <p class="text-slate-500 text-sm mt-2">{{ t('pages.login.subtitle') }}</p>
       </div>
 
       <form @submit.prevent="handleLogin" class="space-y-6">
         <div>
-          <label class="block text-sm font-medium text-slate-700 mb-1">Business Email</label>
+          <label class="block text-sm font-medium text-slate-700 mb-1">{{ t('pages.login.email_label') }}</label>
           <input v-model="form.email" type="email" required
             class="w-full px-4 py-2 rounded-lg border border-slate-300 focus:ring-2 focus:ring-indigo-500 outline-none transition-all"
-            placeholder="admin@enterprise.uk" />
+            :placeholder="t('pages.login.email_placeholder')" />
         </div>
 
         <div>
-          <label class="block text-sm font-medium text-slate-700 mb-1">Password</label>
+          <label class="block text-sm font-medium text-slate-700 mb-1">{{ t('pages.login.password_label') }}</label>
           <input v-model="form.password" type="password" required
             class="w-full px-4 py-2 rounded-lg border border-slate-300 focus:ring-2 focus:ring-indigo-500 outline-none transition-all"
             placeholder="••••••••" />
         </div>
 
         <AppButton :loading="loading" class="w-full py-3">
-          Sign In
+          {{ t('pages.login.sign_in') }}
         </AppButton>
 
         <p v-if="error" class="text-center text-sm text-red-600 font-medium bg-red-50 py-2 rounded-lg animate-pulse">
@@ -42,6 +46,7 @@
 
   const { login } = useAuth()
   const { addToast } = useToast()
+  const { t } = useI18n()
 
   const form = reactive({ email: '', password: '' })
   const loading = ref(false)
@@ -52,10 +57,10 @@
     error.value = ""
     try {
       await login(form)
-      addToast('Welcome back!', 'success')
+      addToast(t('pages.login.messages.login_success'), 'success')
     } catch (e: any) {
       error.value = e
-      addToast('Authentication failed', 'error')
+      addToast(t('pages.login.messages.login_error'), 'error')
     } finally {
       loading.value = false
     }

--- a/apps/web/app/pages/profile.vue
+++ b/apps/web/app/pages/profile.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="max-w-4xl mx-auto">
     <div class="mb-8">
-      <h1 class="text-2xl font-bold text-slate-900">Account Settings</h1>
-      <p class="text-slate-500">Manage your personal information and security preferences.</p>
+      <h1 class="text-2xl font-bold text-slate-900">{{ t('pages.profile.title') }}</h1>
+      <p class="text-slate-500">{{ t('pages.profile.subtitle') }}</p>
     </div>
 
     <!-- Profile Card -->
@@ -21,31 +21,27 @@
           <div class="flex-1 space-y-6">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div>
-                <label class="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1">Email
-                  Address</label>
+                <label class="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1">{{ t('pages.profile.labels.email') }}</label>
                 <p class="text-slate-900 font-medium">{{ user?.email }}</p>
               </div>
               <div>
-                <label class="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1">Account
-                  Role</label>
+                <label class="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1">{{ t('pages.profile.labels.role') }}</label>
                 <span
                   class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-50 text-indigo-700 border border-indigo-100">
                   {{ user?.role }}
                 </span>
               </div>
               <div>
-                <label class="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1">Member
-                  Since</label>
+                <label class="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1">{{ t('pages.profile.labels.member_since') }}</label>
                 <p class="text-slate-900 font-medium">
-                  {{ user ? new Date(user.created).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year:
-                  'numeric' }) : '...' }}
+                  {{ user ? formatDate(user.created) : '...' }}
                 </p>
               </div>
               <div>
-                <label class="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1">Status</label>
+                <label class="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1">{{ t('pages.profile.labels.status') }}</label>
                 <div class="flex items-center gap-1.5 text-emerald-600 font-medium">
                   <span class="h-2 w-2 rounded-full bg-emerald-500"></span>
-                  Active
+                  {{ t('pages.profile.labels.active') }}
                 </div>
               </div>
             </div>
@@ -56,10 +52,10 @@
       <!-- Footer Info -->
       <div class="bg-slate-50 px-8 py-4 border-t border-slate-200 flex justify-between items-center">
         <p class="text-xs text-slate-500">
-          Your unique identifier: <span class="font-mono">{{ user?.id }}</span>
+          {{ t('pages.profile.labels.unique_id') }}: <span class="font-mono">{{ user?.id }}</span>
         </p>
-        <AppButton variant="ghost" class="text-xs" @click="addToast('Contact your admin to change email', 'info')">
-          Request Changes
+        <AppButton variant="ghost" class="text-xs" @click="addToast(t('pages.profile.actions.contact_admin'), 'info')">
+          {{ t('pages.profile.actions.request_changes') }}
         </AppButton>
       </div>
     </div>
@@ -70,15 +66,14 @@
         <div class="p-2 bg-slate-100 rounded-lg text-slate-600">
           <Icon name="heroicons:shield-check" class="w-6 h-6" />
         </div>
-        <h2 class="text-lg font-bold text-slate-900">Security & Privacy</h2>
+        <h2 class="text-lg font-bold text-slate-900">{{ t('pages.profile.security.title') }}</h2>
       </div>
       <p class="text-sm text-slate-600 mb-6">
-        Authenticated sessions are managed via secure JWT tokens with 1-hour expiration, following UK cybersecurity
-        standards.
+        {{ t('pages.profile.security.description') }}
       </p>
       <div class="flex gap-4">
-        <AppButton variant="primary" disabled>Change Password</AppButton>
-        <AppButton variant="ghost" disabled>Enable 2FA</AppButton>
+        <AppButton variant="primary" disabled>{{ t('pages.profile.security.change_password') }}</AppButton>
+        <AppButton variant="ghost" disabled>{{ t('pages.profile.security.enable_2fa') }}</AppButton>
       </div>
     </div>
   </div>
@@ -87,10 +82,14 @@
 <script setup lang="ts">
   const { getMe } = useUsers()
   const { addToast } = useToast()
+  const { t } = useI18n()
+  const { formatDate } = useFormatters()
+  
+  useHead({ title: `${t('pages.profile.title')} | ${t('title')}` })
 
   const { data: user, pending, error } = await getMe()
 
   if (error.value) {
-    addToast('Failed to load profile data', 'error')
+    addToast(t('pages.profile.errors.load_fail'), 'error')
   }
 </script>

--- a/apps/web/app/pages/users.vue
+++ b/apps/web/app/pages/users.vue
@@ -1,17 +1,17 @@
 <template>
   <div class="max-w-4xl mx-auto py-10 px-4">
     <header class="flex justify-between items-center mb-8">
-      <h1 class="text-2xl font-bold text-gray-800">User Management</h1>
+      <h1 class="text-2xl font-bold text-gray-800">{{ $t('pages.users.title') }}</h1>
       <button @click="showForm = !showForm"
         class="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition">
-        {{ showForm ? 'Close' : 'Add New User' }}
+        {{ showForm ? $t('pages.users.close_form') : $t('pages.users.add_user') }}
       </button>
 
       <!-- Search Bar -->
       <div class="relative w-64">
         <Icon :name="pending ? 'heroicons:arrow-path' : 'heroicons:magnifying-glass'"
           :class="['absolute left-3 top-2.5 w-5 h-5', pending ? 'text-indigo-600 animate-spin' : 'text-slate-400']" />
-        <input v-model="searchTerm" type="text" placeholder="Search by email..."
+        <input v-model="searchTerm" type="text" :placeholder="$t('pages.users.search_placeholder')"
           class="pl-10 pr-4 py-2 w-full rounded-lg border border-slate-300 focus:ring-2 focus:ring-indigo-500 outline-none text-sm" />
       </div>
     </header>
@@ -21,36 +21,36 @@
       <form @submit.prevent="handleCreate" class="flex gap-4 items-end">
         <!-- Email -->
         <div class="flex-1">
-          <label class="block text-sm font-medium text-gray-700 mb-1">Email Address</label>
-          <input v-model="form.email" type="email" required placeholder="example@uk-market.com"
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('pages.users.form.email_label') }}</label>
+          <input v-model="form.email" type="email" required :placeholder="$t('pages.users.form.email_placeholder')"
             class="w-full px-4 py-2 rounded-md border border-gray-300 focus:ring-2 focus:ring-indigo-500 outline-none" />
         </div>
         <!-- Password -->
         <div class="flex-1 w-full">
-          <label class="block text-sm font-medium text-gray-700 mb-1">Password</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('pages.users.form.password_label') }}</label>
           <input v-model="form.password" type="password" required
             class="w-full px-4 py-2 rounded-md border border-gray-300 focus:ring-2 focus:ring-indigo-500 outline-none"
-            placeholder="Min. 8 characters" />
+            :placeholder="$t('pages.users.form.password_placeholder')" />
         </div>
         <!-- Role -->
         <div class="w-full lg:w-40">
-          <label class="block text-sm font-medium text-slate-700 mb-1">Role</label>
+          <label class="block text-sm font-medium text-slate-700 mb-1">{{ $t('pages.users.form.role_label') }}</label>
           <select v-model="form.role"
             class="w-full px-4 py-2 rounded-lg border border-slate-300 bg-white focus:ring-2 focus:ring-indigo-500 outline-none appearance-none">
-            <option value="user">User</option>
-            <option value="admin">Admin</option>
+            <option value="user">{{ $t('pages.users.form.role_user') }}</option>
+            <option value="admin">{{ $t('pages.users.form.role_admin') }}</option>
           </select>
         </div>
         <button type="submit" :disabled="loading"
           class="bg-green-600 text-white px-6 py-2 rounded-md hover:bg-green-700 disabled:opacity-50">
-          {{ loading ? 'Saving...' : 'Save User' }}
+          {{ loading ? $t('pages.users.form.submitting') : $t('pages.users.form.submit') }}
         </button>
       </form>
       <p v-if="errorMessage" class="mt-2 text-sm text-red-600">{{ errorMessage }}</p>
     </div>
 
     <!-- Pagination -->
-    <AppPagination v-if="data?.items.length" :type="'users'" :current-page="page" :total-pages="data.pages" :total-items="data.total"
+    <AppPagination v-if="data?.items.length" :type="$t('pages.users.type')" :current-page="page" :total-pages="data.pages" :total-items="data.total"
       :loading="pending" @change="(newPage) => page = newPage" />
 
     <!-- User List Table -->
@@ -58,10 +58,10 @@
       <table :class="{ 'opacity-50': pending }" class="w-full text-left">
         <thead class="bg-gray-50 border-b border-gray-200">
           <tr>
-            <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">Email</th>
-            <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">Role</th>
-            <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">Created At</th>
-            <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">Actions</th>
+            <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">{{ $t('pages.users.table.email') }}</th>
+            <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">{{ $t('pages.users.table.role') }}</th>
+            <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">{{ $t('pages.users.table.created_at') }}</th>
+            <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">{{ $t('pages.users.table.actions') }}</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200">
@@ -76,12 +76,12 @@
                 </span>
               </td>
               <td class="px-6 py-4 text-sm text-gray-500">
-                {{ new Date(user.created).toLocaleDateString('en-GB') }}
+                {{ formatDate(user.created) }}
               </td>
               <td class="px-6 py-4 text-sm">
                 <AppButton variant="danger" class="text-red-600 hover:text-red-800" :loading="isDeleting === user.id"
                   @click="openDeleteModal(user.id)">
-                  Delete
+                  {{ $t('pages.users.table.delete') }}
                 </AppButton>
               </td>
             </tr>
@@ -92,12 +92,12 @@
                 <div class="p-3 bg-slate-100 rounded-full mb-4">
                   <Icon name="heroicons:magnifying-glass" class="w-8 h-8 text-slate-400" />
                 </div>
-                <h3 class="text-sm font-semibold text-slate-900">No users found</h3>
+                <h3 class="text-sm font-semibold text-slate-900">{{ $t('pages.users.no_users_found') }}</h3>
                 <p class="text-sm text-slate-500 mt-1">
-                  We couldn't find any users matching "{{ searchTerm }}".
+                  {{ $t('pages.users.messages.no_results', { search: searchTerm }) }}
                 </p>
                 <AppButton variant="ghost" class="mt-4 text-indigo-600" @click="searchTerm = ''">
-                  Clear search
+                  {{ $t('pages.users.clear_search') }}
                 </AppButton>
               </div>
             </td>
@@ -123,7 +123,7 @@
     </div>
 
     <!-- Pagination -->
-    <AppPagination v-if="data?.items.length" :type="'users'" :current-page="page" :total-pages="data.pages"
+    <AppPagination v-if="data?.items.length" :type="$t('pages.users.type')" :current-page="page" :total-pages="data.pages"
       :total-items="data.total" :loading="pending" @change="(newPage) => page = newPage" />
 
     <!-- Deletion Confirmation Modal -->
@@ -135,19 +135,18 @@
         </div>
       </template>
     
-      <template #title>Confirm Deletion</template>
+      <template #title>{{ t('pages.users.confirm_deletion.title') }}</template>
     
       <template #description>
-        Are you sure you want to delete this user? This action cannot be undone and will permanently remove the data from
-        our servers.
+        {{ t('pages.users.confirm_deletion.message') }}
       </template>
     
       <template #actions>
         <AppButton variant="danger" :loading="isDeleting === userIdToDelete" @click="confirmDelete">
-          Delete User
+          {{ t('pages.users.confirm_deletion.confirm') }}
         </AppButton>
         <AppButton variant="ghost" @click="isModalOpen = false">
-          Cancel
+          {{ t('pages.users.confirm_deletion.cancel') }}
         </AppButton>
       </template>
     </AppModal>
@@ -155,8 +154,12 @@
 </template>
 
 <script setup lang="ts">
-  const searchTerm = ref('')
-  const page = ref(1)
+  const { t, locale } = useI18n()
+  const { formatDate } = useFormatters()
+  const route = useRoute()
+  const router = useRouter()
+
+  useHead({ title: `${t('pages.users.title')} | ${t('title')}` })
 
   const roleStyles = {
     admin: 'bg-indigo-100 text-indigo-700 border-indigo-200',
@@ -166,6 +169,9 @@
   const { addToast } = useToast()
   const { fetchUsers, createUser } = useUsers()
   
+  const searchTerm = ref(route.query.search?.toString() || '')
+  const page = ref(Number(route.query.page) || 1)
+
   const { data, refresh, pending } = await fetchUsers(() => searchTerm.value, page)
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -174,12 +180,23 @@
     if (debounceTimer) clearTimeout(debounceTimer)
     debounceTimer = setTimeout(async () => {
       page.value = 1
+      router.push({
+        query: { ...route.query, search: newValue || undefined, page: page.value }
+      })
       const result = await refresh()
     }, 1000) // 300ms delay for debouncing
   })
 
   watch(page, (newValue) => {
     const result = refresh()
+  })
+
+  watch(locale, () => {
+    refresh()
+  })
+
+  watch(() => route.query.search, (newSearch) => {
+    searchTerm.value = newSearch?.toString() || ''
   })
 
   const showForm = ref(false)
@@ -200,10 +217,10 @@
       form.password = ''
       form.role = 'user'
       showForm.value = false
-      addToast('User created successfully!', 'success')
+      addToast(t('pages.users.messages.success_create'), 'success')
       await refresh()
     } catch (e: any) {
-      addToast(e.data?.message || 'Error creating user', 'error')
+      addToast(e.data?.message || t('pages.users.messages.error_create'), 'error')
     } finally {
       loading.value = false
     }
@@ -227,13 +244,13 @@
     try {
       const { deleteUser } = useUsers()
       await deleteUser(id)
-      addToast('User deleted forever.', 'success')
+      addToast(t('pages.users.messages.success_delete'), 'success')
 
       await refresh()
       isModalOpen.value = false
 
     } catch (e: any) {
-      const message = e.data?.message || 'Failed to delete user'
+      const message = e.data?.message || t('pages.users.messages.error_delete')
       addToast(message, 'error')
       console.error('Delete error:', e)
     } finally {

--- a/apps/web/nuxt.config.ts
+++ b/apps/web/nuxt.config.ts
@@ -7,7 +7,8 @@ export default defineNuxtConfig({
 
   modules: [
     '@nuxtjs/tailwindcss',
-    '@nuxt/icon'
+    '@nuxt/icon',
+    '@nuxtjs/i18n'
   ],
 
   icon: {
@@ -20,6 +21,21 @@ export default defineNuxtConfig({
     exposeConfig: true,
     viewer: true,
   },
+
+  i18n: {
+    locales: [
+      { code: 'en', iso: 'en-GB', file: 'en-GB.json', name: 'English' },
+      { code: 'pt', iso: 'pt-BR', file: 'pt-BR.json', name: 'Português' },
+      { code: 'es', iso: 'es-ES', file: 'es-ES.json', name: 'Español' }
+    ],
+    lazy: true,
+    langDir: '../app/locales/',
+    defaultLocale: 'en',
+    strategy: 'prefix_except_default',
+    skipSettingLocaleOnNavigate: false,
+    detectBrowserLanguage: false, 
+  },
+
   build: {
     transpile: ['@enterprise/api-contracts']
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@iconify-json/heroicons": "^1.2.3",
     "@nuxt/icon": "^2.2.1",
     "@nuxt/test-utils": "^4.0.2",
+    "@nuxtjs/i18n": "^10.3.0",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@vue/test-utils": "^2.4.8",
     "happy-dom": "^20.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       '@nuxt/test-utils':
         specifier: ^4.0.2
         version: 4.0.2(@jest/globals@30.3.0)(@vue/test-utils@2.4.8(@vue/compiler-dom@3.5.32)(@vue/server-renderer@3.5.32(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.9.0)(magicast@0.5.2)(playwright-core@1.59.1)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
+      '@nuxtjs/i18n':
+        specifier: ^10.3.0
+        version: 10.3.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)(@vue/compiler-dom@3.5.32)(db0@0.3.4(@electric-sql/pglite@0.4.1)(mysql2@3.15.3))(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))
       '@nuxtjs/tailwindcss':
         specifier: ^6.14.0
         version: 6.14.0(magicast@0.5.2)(yaml@2.8.3)
@@ -651,16 +654,34 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -669,16 +690,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -687,10 +726,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -699,10 +750,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -711,10 +774,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -723,10 +798,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -735,10 +822,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -747,16 +846,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -765,10 +882,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -777,11 +906,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -789,16 +930,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -1031,6 +1190,84 @@ packages:
       '@types/node':
         optional: true
 
+  '@intlify/bundle-utils@11.1.2':
+    resolution: {integrity: sha512-/Cd1MKb7L0SFnIvyhZO0YF4W+jSIY4BQ2PgiT0jP+tc1PO/W2mAOOx4/GecjA21oPhtSxyZd13vFAZnGGeZYVQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      petite-vue-i18n: '*'
+      vue-i18n: '*'
+    peerDependenciesMeta:
+      petite-vue-i18n:
+        optional: true
+      vue-i18n:
+        optional: true
+
+  '@intlify/core-base@11.4.0':
+    resolution: {integrity: sha512-nlxFOnmjJgVkL1PsuSMagyh3qIHTwc2KlO2R3qQQV1ydrcwh1XpM7opWUGqvGaLlktttopDzbLBpr/k5tvbNmA==}
+    engines: {node: '>= 16'}
+
+  '@intlify/core@11.4.0':
+    resolution: {integrity: sha512-wNbWZsOFFtLumL+dlQT88zJMw5GpnGPLHJzuRFSS+ZTubMxGvAHwNp7ZvaMBHI4DLtFspq7XpC2UXERwPmuQgQ==}
+    engines: {node: '>= 16'}
+
+  '@intlify/devtools-types@11.4.0':
+    resolution: {integrity: sha512-LtQ04kG8/2Nv6AbuINpkjODuhKHdd+MGLlXKW3I0GTCeDsDIBZUot82nnyK7D6+qersF08FqSvoN/eGPcL3c7Q==}
+    engines: {node: '>= 16'}
+
+  '@intlify/h3@0.7.4':
+    resolution: {integrity: sha512-BtL5+U3Dd9Qz6so+ArOMQWZ+nV21rOqqYUXnqwvW6J3VUXr66A9+9+vUFb/NAQvOU4kdfkO3c/9LMRGU9WZ8vw==}
+    engines: {node: '>= 20'}
+
+  '@intlify/message-compiler@11.4.0':
+    resolution: {integrity: sha512-v455gVZqMb0er63Wd/akX8DXTnwSubgrgQaRigLB60V3xpnq3B99oPvGXW+N4G/5QFt8Ls84FJ8qHJUVnRCs1A==}
+    engines: {node: '>= 16'}
+
+  '@intlify/shared@11.4.0':
+    resolution: {integrity: sha512-r9qUeLeO0TMZmUZ+mXS6IGQ6xwzZJaVMK6j4CdoA3eQP8xp3JtCfwkZ30gB4+knlN40pmBdDXgx85SWhMCzHng==}
+    engines: {node: '>= 16'}
+
+  '@intlify/unplugin-vue-i18n@11.1.2':
+    resolution: {integrity: sha512-3RUsT7ss+dzl12bu0MW6sWdy8fZ2rsysH+4fZnMF+ANK5UQ2nhGSw1795YoHtH0rZTDI198PdfodZfyrdt4KYw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      petite-vue-i18n: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.2.25
+      vue-i18n: '*'
+    peerDependenciesMeta:
+      petite-vue-i18n:
+        optional: true
+      vite:
+        optional: true
+      vue-i18n:
+        optional: true
+
+  '@intlify/utils@0.13.0':
+    resolution: {integrity: sha512-8i3uRdAxCGzuHwfmHcVjeLQBtysQB2aXl/ojoagDut5/gY5lvWCQ2+cnl2TiqE/fXj/D8EhWG/SLKA7qz4a3QA==}
+    engines: {node: '>= 18'}
+
+  '@intlify/utils@0.14.1':
+    resolution: {integrity: sha512-/NVDhX6sG87h0PXIwUCTW9DeHbKeqlni6qVV8xzMULQRHE9azIETldBlTKaBji7z6ostyDIH4s6SWI3AAI4uFg==}
+    engines: {node: '>= 20'}
+
+  '@intlify/vue-i18n-extensions@8.0.0':
+    resolution: {integrity: sha512-w0+70CvTmuqbskWfzeYhn0IXxllr6mU+IeM2MU0M+j9OW64jkrvqY+pYFWrUnIIC9bEdij3NICruicwd5EgUuQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@intlify/shared': ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@vue/compiler-dom': ^3.0.0
+      vue: ^3.0.0
+      vue-i18n: ^9.0.0 || ^10.0.0 || ^11.0.0
+    peerDependenciesMeta:
+      '@intlify/shared':
+        optional: true
+      '@vue/compiler-dom':
+        optional: true
+      vue:
+        optional: true
+      vue-i18n:
+        optional: true
+
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
@@ -1182,6 +1419,11 @@ packages:
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
+  '@miyaneee/rollup-plugin-json5@1.2.0':
+    resolution: {integrity: sha512-JjTIaXZp9WzhUHpElrqPnl1AzBi/rvRs065F71+aTmlqvTMVkdbjZ8vfFl4nRlgJy+TPBw69ZK4pwFdmOAt4aA==}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
 
   '@napi-rs/nice-android-arm-eabi@1.1.1':
     resolution: {integrity: sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==}
@@ -1576,6 +1818,10 @@ packages:
       rollup-plugin-visualizer:
         optional: true
 
+  '@nuxtjs/i18n@10.3.0':
+    resolution: {integrity: sha512-qomybFaGXQ2RveUOVIQvjOmoeiyd60E22RVseMk9hgjgayDHnLfEpUyLWBam1cMyjMO4FXBvwGRgTEiszsNnvQ==}
+    engines: {node: '>=20.11.1'}
+
   '@nuxtjs/tailwindcss@6.14.0':
     resolution: {integrity: sha512-30RyDK++LrUVRgc2A85MktGWIZoRQgeQKjE4CjjD64OXNozyl+4ScHnnYgqVToMM6Ch2ZG2W4wV2J0EN6F0zkQ==}
 
@@ -1701,10 +1947,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxc-parser/binding-android-arm-eabi@0.112.0':
+    resolution: {integrity: sha512-retxBzJ39Da7Lh/eZTn9+HJgTeDUxZIpuI0urOsmcFsBKXAth3lc1jIvwseQ9qbAI/VrsoFOXiGIzgclARbAHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxc-parser/binding-android-arm-eabi@0.117.0':
     resolution: {integrity: sha512-XarGPJpaobgKjfm7xRfCGWWszuPbm/OeP91NdMhxtcLZ/qLTmWF0P0z0gqmr0Uysi1F1v1BNtcST11THMrcEOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.112.0':
+    resolution: {integrity: sha512-pRkbBRbuIIsufUWpOJ+JHWfJFNupkidy4sbjfcm37e6xwYrn9LSKMLubPHvNaL1Zf92ZRhGiwaYkEcmaFg2VcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
     os: [android]
 
   '@oxc-parser/binding-android-arm64@0.117.0':
@@ -1713,10 +1971,22 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@oxc-parser/binding-darwin-arm64@0.112.0':
+    resolution: {integrity: sha512-fh6/KQL/cbH5DukT3VkdCqnULLuvVnszVKySD5IgSE0WZb32YZo/cPsPdEv052kk6w3N4agu+NTiMnZjcvhUIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxc-parser/binding-darwin-arm64@0.117.0':
     resolution: {integrity: sha512-3bAEpyih6r/Kb+Xzn1em1qBMClOS7NsVWgF86k95jpysR5ix/HlKFKSy7cax6PcS96HeHR4kjlME20n/XK1zNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.112.0':
+    resolution: {integrity: sha512-vUBOOY1E30vlu/DoTGDoT1UbLlwu5Yv9tqeBabAwRzwNDz8Skho16VKhsBDUiyqddtpsR3//v6vNk38w4c+6IA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@oxc-parser/binding-darwin-x64@0.117.0':
@@ -1725,14 +1995,32 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@oxc-parser/binding-freebsd-x64@0.112.0':
+    resolution: {integrity: sha512-hnEtO/9AVnYWzrgnp6L+oPs/6UqlFeteUL6n7magkd2tttgmx1C01hyNNh6nTpZfLzEVJSNJ0S+4NTsK2q2CxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-parser/binding-freebsd-x64@0.117.0':
     resolution: {integrity: sha512-xH76lqSdjCSY0KUMPwLXlvQ3YEm3FFVEQmgiOCGNf+stZ6E4Mo3nC102Bo8yKd7aW0foIPAFLYsHgj7vVI/axw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.112.0':
+    resolution: {integrity: sha512-WxJrUz3pcIc2hp4lvJbvt/sTL33oX9NPvkD3vDDybE6tc0V++rS+hNOJxwXdD2FDIFPkHs/IEn5asEZFVH+VKw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.117.0':
     resolution: {integrity: sha512-9Hdm1imzrn4RdMYnQKKcy+7p7QsSPIrgVIZmpGSJT02nYDuBWLdG1pdYMPFoEo46yiXry3tS3RoHIpNbT1IiyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.112.0':
+    resolution: {integrity: sha512-jj8A8WWySaJQqM9XKAIG8U2Q3qxhFQKrXPWv98d1oC35at+L1h+C+V4M3l8BAKhpHKCu3dYlloaAbHd5q1Hw6A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1743,8 +2031,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm64-gnu@0.112.0':
+    resolution: {integrity: sha512-G2F8H6FcAExVK5vvhpSh61tqWx5QoaXXUnSsj5FyuDiFT/K7AMMVSQVqnZREDc+YxhrjB0vnKjCcuobXK63kIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm64-gnu@0.117.0':
     resolution: {integrity: sha512-jBxD7DtlHQ36ivjjZdH0noQJgWNouenzpLmXNKnYaCsBfo3jY95m5iyjYQEiWkvkhJ3TJUAs7tQ1/kEpY7x/Kg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.112.0':
+    resolution: {integrity: sha512-3R0iqjM3xYOZCnwgcxOQXH7hrz64/USDIuLbNTM1kZqQzRqaR4w7SwoWKU934zABo8d0op2oSwOp+CV3hZnM7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1755,14 +2055,32 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-ppc64-gnu@0.112.0':
+    resolution: {integrity: sha512-lAQf8PQxfgy7h0bmcfSVE3hg3qMueshPYULFsCrHM+8KefGZ9W+ZMvRyU33gLrB4w1O3Fz1orR0hmKMCRxXNrQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.117.0':
     resolution: {integrity: sha512-RPddpcE/0xxWaommWy0c5i/JdrXcXAkxBS2GOrAUh5LKmyCh03hpJedOAWszG4ADsKQwoUQQ1/tZVGRhZIWtKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.112.0':
+    resolution: {integrity: sha512-2QlvQBUhHuAE3ezD4X3CAEKMXdfgInggQ5Bj/7gb5NcYP3GyfLTj7c+mMu+BRwfC9B3AXBNyqHWbqEuuUvZyRQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
   '@oxc-parser/binding-linux-riscv64-gnu@0.117.0':
     resolution: {integrity: sha512-ur/WVZF9FSOiZGxyP+nfxZzuv6r5OJDYoVxJnUR7fM/hhXLh4V/be6rjbzm9KLCDBRwYCEKJtt+XXNccwd06IA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.112.0':
+    resolution: {integrity: sha512-v06iu0osHszgqJ1dLQRb6leWFU1sjG/UQk4MoVBtE6ZPewgfTkby6G9II1SpEAf2onnAuQceVYxQH9iuU3NJqw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -1773,14 +2091,32 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.112.0':
+    resolution: {integrity: sha512-+5HhNHtxsdcd7+ljXFnn9FOoCNXJX3UPgIfIE6vdwS1HqdGNH6eAcVobuqGOp54l8pvcxDQA6F4cPswCgLrQfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
   '@oxc-parser/binding-linux-s390x-gnu@0.117.0':
     resolution: {integrity: sha512-hbsfKjUwRjcMZZvvmpZSc+qS0bHcHRu8aV/I3Ikn9BzOA0ZAgUE7ctPtce5zCU7bM8dnTLi4sJ1Pi9YHdx6Urw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
+  '@oxc-parser/binding-linux-x64-gnu@0.112.0':
+    resolution: {integrity: sha512-jKwO7ZLNkjxwg7FoCLw+fJszooL9yXRZsDN0AQ1AQUTWq1l8GH/2e44k68N3fcP19jl8O8jGpqLAZcQTYk6skA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
   '@oxc-parser/binding-linux-x64-gnu@0.117.0':
     resolution: {integrity: sha512-1QrTrf8rige7UPJrYuDKJLQOuJlgkt+nRSJLBMHWNm9TdivzP48HaK3f4q18EjNlglKtn03lgjMu4fryDm8X4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-musl@0.112.0':
+    resolution: {integrity: sha512-TYqnuKV/p3eOc+N61E0961nA7DC+gaCeJ3+V2LcjJdTwFMdikqWL6uVk1jlrpUCBrozHDATVUKDZYH7r4FQYjQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1791,21 +2127,44 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@oxc-parser/binding-openharmony-arm64@0.112.0':
+    resolution: {integrity: sha512-ZhrVmWFifVEFQX4XPwLoVFDHw9tAWH9p9vHsHFH+5uCKdfVR+jje4WxVo6YrokWCboGckoOzHq5KKMOcPZfkRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@oxc-parser/binding-openharmony-arm64@0.117.0':
     resolution: {integrity: sha512-QPJvFbnnDZZY7xc+xpbIBWLThcGBakwaYA9vKV8b3+oS5MGfAZUoTFJcix5+Zg2Ri46sOfrUim6Y6jsKNcssAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
+  '@oxc-parser/binding-wasm32-wasi@0.112.0':
+    resolution: {integrity: sha512-Gr8X2PUU3hX1g3F5oLWIZB8DhzDmjr5TfOrmn5tlBOo9l8ojPGdKjnIBfObM7X15928vza8QRKW25RTR7jfivg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
   '@oxc-parser/binding-wasm32-wasi@0.117.0':
     resolution: {integrity: sha512-+XRSNA0xt3pk/6CUHM7pykVe7M8SdifJk8LX1+fIp/zefvR3HBieZCbwG5un8gogNgh7srLycoh/cQA9uozv5g==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@oxc-parser/binding-win32-arm64-msvc@0.112.0':
+    resolution: {integrity: sha512-t5CDLbU70Ea88bGRhvU/dLJTc/Wcrtf2Jp534E8P3cgjAvHDjdKsfDDqBZrhybJ8Jv9v9vW5ngE40EK51BluDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@oxc-parser/binding-win32-arm64-msvc@0.117.0':
     resolution: {integrity: sha512-GpxeGS+Vo030DsrXeRPc7OSJOQIyAHkM3mzwBcnQjg/79XnOIDDMXJ5X6/aNdkVt/+Pv35pqKzGA4TQau97x8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.112.0':
+    resolution: {integrity: sha512-rZH0JynCCwnhe2HfRoyNOl/Kfd9pudoWxgpC5OZhj7j77pMK0UOAa35hYDfrtSOUk2HLzrikV5dPUOY2DpSBSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
     os: [win32]
 
   '@oxc-parser/binding-win32-ia32-msvc@0.117.0':
@@ -1814,19 +2173,40 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@oxc-parser/binding-win32-x64-msvc@0.112.0':
+    resolution: {integrity: sha512-oGHluohzmVFAuQrkEnl1OXAxMz2aYmimxUqIgKXpBgbr7PvFv0doELB273sX+5V3fKeggohKg1A2Qq21W9Z9cQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-parser/binding-win32-x64-msvc@0.117.0':
     resolution: {integrity: sha512-ysRJAjIbB4e5y+t9PZs7TwbgOV/GVT//s30AORLCT/pedYwpYzHq6ApXK7is9fvyfZtgT3anNir8+esurmyaDw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
+  '@oxc-project/types@0.112.0':
+    resolution: {integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==}
+
   '@oxc-project/types@0.117.0':
     resolution: {integrity: sha512-C/kPXBphID44fXdsa2xSOCuzX8fKZiFxPsvucJ6Yfkr6CJlMA+kNLPNKyLoI+l9XlDsNxBrz6h7IIjKU8pB69w==}
+
+  '@oxc-transform/binding-android-arm-eabi@0.112.0':
+    resolution: {integrity: sha512-r4LuBaPnOAi0eUOBNi880Fm2tO2omH7N1FRrL6+nyz/AjQ+QPPLtoyZJva0O+sKi1buyN/7IzM5p9m+5ANSDbg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
 
   '@oxc-transform/binding-android-arm-eabi@0.117.0':
     resolution: {integrity: sha512-17giX7h5VR9Eodru4OoSCFdgwLFIaUxeEn8JWe0vMZrAuRbT9NiDTy5dXdbGQBoO8aXPkbGS38FGlvbi31aujw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
+    os: [android]
+
+  '@oxc-transform/binding-android-arm64@0.112.0':
+    resolution: {integrity: sha512-ve46vQcQrY8eGe8990VSlS9gkD+AogJqbtfOkeua+5sQGQTDgeIRRxOm7ktCo19uZc2bEBwXRJITgosd+NRVmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
     os: [android]
 
   '@oxc-transform/binding-android-arm64@0.117.0':
@@ -1835,10 +2215,22 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@oxc-transform/binding-darwin-arm64@0.112.0':
+    resolution: {integrity: sha512-ddbmLU3Tr+i7MOynfwAXxUXud3SjJKlv7XNjaq08qiI8Av/QvhXVGc2bMhXkWQSMSBUeTDoiughKjK+Zsb6y/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxc-transform/binding-darwin-arm64@0.117.0':
     resolution: {integrity: sha512-K1Xo52xJOvFfHSkz2ax9X5Qsku23RCfTIPbHZWdUCAQ1TQooI+sFcewSubhVUJ4DVK12/tYT//XXboumin+FHA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform/binding-darwin-x64@0.112.0':
+    resolution: {integrity: sha512-TKvmNw96jQZPqYb4pRrzLFDailNB3YS14KNn+x2hwRbqc6CqY96S9PYwyOpVpYdxfoRjYO9WgX9SoS+62a1DPA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@oxc-transform/binding-darwin-x64@0.117.0':
@@ -1847,14 +2239,32 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@oxc-transform/binding-freebsd-x64@0.112.0':
+    resolution: {integrity: sha512-YPMkSCDaelO8HHYRMYjm+Q+IfkfIbdtQzwPuasItYkq8UUkNeHNPheNh2JkvQa3c+io3E9ePOgHQ2yihpk7o/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-transform/binding-freebsd-x64@0.117.0':
     resolution: {integrity: sha512-QDRyw0atg9BMnwOwnJeW6REzWPLEjiWtsCc2Sj612F1hCdvP+n0L3o8sHinEWM+BiOkOYtUxHA69WjUslc3G+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.112.0':
+    resolution: {integrity: sha512-nA7kzQGNEpuTRknst/IJ3l8hqmDmEda3aun6jkXgp7gKxESjuHeaNH04mKISxvJ7fIacvP2g/wtTSnm4u5jL8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxc-transform/binding-linux-arm-gnueabihf@0.117.0':
     resolution: {integrity: sha512-UvpvOjyQVgiIJahIpMT0qAsLJT8O1ibHTBgXGOsZkQgw1xmjARPQ07dpRcucPPn6cqCF3wrxfbqtr2vFHaMkdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.112.0':
+    resolution: {integrity: sha512-w8GuLmckKlGc3YujaZKhtbFxziCcosvM2l9GnQjCb/yENWLGDiyQOy0BTAgPGdJwpYTiOeJblEXSuXYvlE1Ong==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1865,8 +2275,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxc-transform/binding-linux-arm64-gnu@0.112.0':
+    resolution: {integrity: sha512-9LwwGnJ8+WT0rXcrI8M0RJtDNt91eMqcDPPEvJxhRFHIMcHTy5D5xT+fOl3Us0yMqKo3HUWkbfUYqAp4GoZ3Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@oxc-transform/binding-linux-arm64-gnu@0.117.0':
     resolution: {integrity: sha512-mXbDfvDN0RZVg7v4LohNzU0kK3fMAZgkUKTkpFVgxEvzibEG5VpSznkypUwHI4a8U8pz+K6mGaLetX3Xt+CvvA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-musl@0.112.0':
+    resolution: {integrity: sha512-Lg6VOuSd3oXv7J0eGywgqh/086h+qQzIBOD+47pYKMTTJcbDe+f3h/RgGoMKJE5HhiwT5sH1aGEJfIfaYUiVSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1877,14 +2299,32 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@oxc-transform/binding-linux-ppc64-gnu@0.112.0':
+    resolution: {integrity: sha512-PXzmj82o1moA4IGphYImTRgc2youTi4VRfyFX3CHwLjxPcQ5JtcsgbDt4QUdOzXZ+zC07s5jf2ZzhRapEOlj2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
   '@oxc-transform/binding-linux-ppc64-gnu@0.117.0':
     resolution: {integrity: sha512-Rvspti4Kr7eq6zSrURK5WjscfWQPvmy/KjJZV45neRKW8RLonE3r9+NgrwSLGoHvQ3F24fbqlkplox1RtlhH5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
+  '@oxc-transform/binding-linux-riscv64-gnu@0.112.0':
+    resolution: {integrity: sha512-vhJsMsVH/6xwa3bt1LGts33FXUkGjaEGDwsRyp4lIfOjSfQVWMtCmWMFNaA0dW9FVWdD2Gt2fSFBSZ+azDxlpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
   '@oxc-transform/binding-linux-riscv64-gnu@0.117.0':
     resolution: {integrity: sha512-Dr2ZW9ZZ4l1eQ5JUEUY3smBh4JFPCPuybWaDZTLn3ADZjyd8ZtNXEjeMT8rQbbhbgSL9hEgbwaqraole3FNThQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.112.0':
+    resolution: {integrity: sha512-cXWFb7z+2IjFUEcXtRwluq9oEG5qnyFCjiu3SWrgYNcWwPdHusv3I/7K5/CTbbi4StoZ5txbi7/iSfDHNyWuRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -1895,14 +2335,32 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@oxc-transform/binding-linux-s390x-gnu@0.112.0':
+    resolution: {integrity: sha512-eEFu4SRqJTJ20/88KRWmp+jpHKAw0Y1DsnSgpEeXyBIIcsOaLIUMU/TfYWUmqRbvbMV9rmOmI3kp5xWYUq6kSQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
   '@oxc-transform/binding-linux-s390x-gnu@0.117.0':
     resolution: {integrity: sha512-qT//IAPLvse844t99Kff5j055qEbXfwzWgvCMb0FyjisnB8foy25iHZxZIocNBe6qwrCYWUP1M8rNrB/WyfS1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
+  '@oxc-transform/binding-linux-x64-gnu@0.112.0':
+    resolution: {integrity: sha512-ST1MDT+TlOyZ1c5btrGinRSUW2Jf4Pa+0gdKwsyjDSOC3dxy2ZNkN3mosTf4ywc3J+mxfYKqtjs7zSwHz03ILA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
   '@oxc-transform/binding-linux-x64-gnu@0.117.0':
     resolution: {integrity: sha512-2YEO5X+KgNzFqRVO5dAkhjcI5gwxus4NSWVl/+cs2sI6P0MNPjqE3VWPawl4RTC11LvetiiZdHcujUCPM8aaUw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-musl@0.112.0':
+    resolution: {integrity: sha512-ISQoA3pD4cyTGpf9sXXeerH6pL2L6EIpdy6oAy2ttkswyVFDyQNVOVIGIdLZDgbpmqGljxZnWqt/J/N68pQaig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1913,16 +2371,33 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@oxc-transform/binding-openharmony-arm64@0.112.0':
+    resolution: {integrity: sha512-UOGVrGIv7yLJovyEXEyUTADuLq98vd/cbMHFLJweRXD+11I8Tn4jASi4WzdsN8C3BVYGRHrXH2NlSBmhz33a4g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@oxc-transform/binding-openharmony-arm64@0.117.0':
     resolution: {integrity: sha512-Ebxx6NPqhzlrjvx4+PdSqbOq+li0f7X59XtJljDghkbJsbnkHvhLmPR09ifHt5X32UlZN63ekjwcg/nbmHLLlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
+  '@oxc-transform/binding-wasm32-wasi@0.112.0':
+    resolution: {integrity: sha512-XIX7Gpq9koAvzBVHDlVFHM79r5uOVK6kTEsdsN4qaajpjkgtv4tdsAOKIYK6l7fUbsbE6xS+6w1+yRFrDeC1kg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
   '@oxc-transform/binding-wasm32-wasi@0.117.0':
     resolution: {integrity: sha512-Nn8mmcBiQ0XKHLTb05QBlH+CDkn7jf5YDVv9FtKhy4zJT0NEU9y3dXVbfcurOpsVrG9me4ktzDQNCaAoJjUQyw==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.112.0':
+    resolution: {integrity: sha512-EgXef9kOne9BNsbYBbuRqxk2hteT0xsAGcx/VbtCBMJYNj8fANFhT271DUSOgfa4DAgrQQmsyt/Kr1aV9mpU9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
 
   '@oxc-transform/binding-win32-arm64-msvc@0.117.0':
     resolution: {integrity: sha512-15cbsF8diXWGnHrTsVgVeabETiT/KdMAfRAcot99xsaVecJs3pITNNjC6Qj+/TPNpehbgIFjlhhxOVSbQsTBgg==}
@@ -1930,10 +2405,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@oxc-transform/binding-win32-ia32-msvc@0.112.0':
+    resolution: {integrity: sha512-6QaB0qjNaou2YR+blncHdw7j0e26IOwOIjLbhVGDeuf9+4rjJeiqRXJ2hOtCcS4zblnao/MjdgQuZ3fM0nl+Kw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxc-transform/binding-win32-ia32-msvc@0.117.0':
     resolution: {integrity: sha512-I6DkhCuFX6p9rckdWiLuZfBWrrYUC7sNX+zLaCfa5zvrPNwo1/29KkefvqXVxu3AWT/6oZAbtc0A8/mqhETJPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-x64-msvc@0.112.0':
+    resolution: {integrity: sha512-FRKYlY959QeqRPx9kXs0HjU2xuXPT1cdF+vvA200D9uAX/KLcC34MwRqUKTYml4kCc2Vf/P2pBR9cQuBm3zECQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [win32]
 
   '@oxc-transform/binding-win32-x64-msvc@0.117.0':
@@ -2258,6 +2745,15 @@ packages:
     engines: {node: '>=20.0.0'}
     peerDependencies:
       rollup: ^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-yaml@4.1.2':
+    resolution: {integrity: sha512-RpupciIeZMUqhgFE97ba0s98mOFS7CWzN3EJNhJkqSv9XLlWYtwVdtE6cDw6ASOF/sZVFS7kRJXftaqM2Vakdw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -2976,6 +3472,9 @@ packages:
 
   '@vue/compiler-ssr@3.5.32':
     resolution: {integrity: sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
   '@vue/devtools-api@8.1.1':
     resolution: {integrity: sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==}
@@ -4239,6 +4738,11 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -4262,6 +4766,11 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   eslint-config-prettier@10.1.1:
     resolution: {integrity: sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==}
@@ -4334,6 +4843,10 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -5363,6 +5876,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-eslint-parser@2.4.2:
+    resolution: {integrity: sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
@@ -5838,6 +6355,9 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  nuxt-define@1.0.0:
+    resolution: {integrity: sha512-CYZ2WjU+KCyCDVzjYUM4eEpMF0rkPmkpiFrybTqqQCRpUbPt2h3snswWIpFPXTi+osRCY6Og0W/XLAQgDL4FfQ==}
+
   nuxt@4.4.2:
     resolution: {integrity: sha512-iWVFpr/YEqVU/CenqIHMnIkvb2HE/9f+q8oxZ+pj2et+60NljGRClCgnmbvGPdmNFE0F1bEhoBCYfqbDOCim3Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5954,8 +6474,16 @@ packages:
     resolution: {integrity: sha512-JHsv/b+bmBJkAzkHXgTN7RThloVxLHPT0ojHfjqxVeHuQB7LPpLUbJ2qfwz37sto9stZ9+AVwUP4b3gtR7p/Tw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  oxc-parser@0.112.0:
+    resolution: {integrity: sha512-7rQ3QdJwobMQLMZwQaPuPYMEF2fDRZwf51lZ//V+bA37nejjKW5ifMHbbCwvA889Y4RLhT+/wLJpPRhAoBaZYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   oxc-parser@0.117.0:
     resolution: {integrity: sha512-l3cbgK5wUvWDVNWM/JFU77qDdGZK1wudnLsFcrRyNo/bL1CyU8pC25vDhMHikVY29lbK2InTWsX42RxVSutUdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-transform@0.112.0:
+    resolution: {integrity: sha512-cIRRvZgrHfsAHrkt8LWdAX4+Do8R0MzQSfeo9yzErzHeYiuyNiP4PCTPbOy/wBXL4MYzt3ebrBa5jt3akQkKAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-transform@0.117.0:
@@ -7228,6 +7756,10 @@ packages:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
 
+  tosource@2.0.0-alpha.3:
+    resolution: {integrity: sha512-KAB2lrSS48y91MzFPFuDg4hLbvDiyTjOVgaK7Erw+5AmZXNq4sFRVn8r6yxSLuNs15PaokrDRpS61ERY9uZOug==}
+    engines: {node: '>=10'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -7748,6 +8280,12 @@ packages:
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
 
+  vue-i18n@11.4.0:
+    resolution: {integrity: sha512-gxLVtcwdvOgwKSzkdb7nHKlW0N85A6aDNmHLnq6V+3w2/BXy/os5l71P7TIlgIQTxX0zJjiz89iImoHi51GieQ==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      vue: ^3.0.0
+
   vue-router@5.0.4:
     resolution: {integrity: sha512-lCqDLCI2+fKVRl2OzXuzdSWmxXFLQRxQbmHugnRpTMyYiT+hNaycV0faqG5FBHDXoYrZ6MQcX87BvbY8mQ20Bg==}
     peerDependencies:
@@ -7910,6 +8448,10 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml-eslint-parser@1.3.2:
+    resolution: {integrity: sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==}
+    engines: {node: ^14.17.0 || >=16.0.0}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -8335,79 +8877,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -8636,6 +9256,86 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@24.12.2)':
     optionalDependencies:
       '@types/node': 24.12.2
+
+  '@intlify/bundle-utils@11.1.2(vue-i18n@11.4.0(vue@3.5.32(typescript@5.9.3)))':
+    dependencies:
+      '@intlify/message-compiler': 11.4.0
+      '@intlify/shared': 11.4.0
+      acorn: 8.16.0
+      esbuild: 0.25.12
+      escodegen: 2.1.0
+      estree-walker: 2.0.2
+      jsonc-eslint-parser: 2.4.2
+      source-map-js: 1.2.1
+      yaml-eslint-parser: 1.3.2
+    optionalDependencies:
+      vue-i18n: 11.4.0(vue@3.5.32(typescript@5.9.3))
+
+  '@intlify/core-base@11.4.0':
+    dependencies:
+      '@intlify/devtools-types': 11.4.0
+      '@intlify/message-compiler': 11.4.0
+      '@intlify/shared': 11.4.0
+
+  '@intlify/core@11.4.0':
+    dependencies:
+      '@intlify/core-base': 11.4.0
+      '@intlify/shared': 11.4.0
+
+  '@intlify/devtools-types@11.4.0':
+    dependencies:
+      '@intlify/core-base': 11.4.0
+      '@intlify/shared': 11.4.0
+
+  '@intlify/h3@0.7.4':
+    dependencies:
+      '@intlify/core': 11.4.0
+      '@intlify/utils': 0.13.0
+
+  '@intlify/message-compiler@11.4.0':
+    dependencies:
+      '@intlify/shared': 11.4.0
+      source-map-js: 1.2.1
+
+  '@intlify/shared@11.4.0': {}
+
+  '@intlify/unplugin-vue-i18n@11.1.2(@vue/compiler-dom@3.5.32)(eslint@9.39.1(jiti@2.6.1))(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vue-i18n@11.4.0(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
+      '@intlify/bundle-utils': 11.1.2(vue-i18n@11.4.0(vue@3.5.32(typescript@5.9.3)))
+      '@intlify/shared': 11.4.0
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.4.0)(@vue/compiler-dom@3.5.32)(vue-i18n@11.4.0(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      '@typescript-eslint/scope-manager': 8.50.0
+      '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.3)
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      pathe: 2.0.3
+      picocolors: 1.1.1
+      unplugin: 2.3.11
+      vue: 3.5.32(typescript@5.9.3)
+    optionalDependencies:
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
+      vue-i18n: 11.4.0(vue@3.5.32(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+
+  '@intlify/utils@0.13.0': {}
+
+  '@intlify/utils@0.14.1': {}
+
+  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.4.0)(@vue/compiler-dom@3.5.32)(vue-i18n@11.4.0(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@babel/parser': 7.29.2
+    optionalDependencies:
+      '@intlify/shared': 11.4.0
+      '@vue/compiler-dom': 3.5.32
+      vue: 3.5.32(typescript@5.9.3)
+      vue-i18n: 11.4.0(vue@3.5.32(typescript@5.9.3))
 
   '@ioredis/commands@1.5.1': {}
 
@@ -8907,6 +9607,12 @@ snapshots:
       - supports-color
 
   '@microsoft/tsdoc@0.16.0': {}
+
+  '@miyaneee/rollup-plugin-json5@1.2.0(rollup@4.60.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      json5: 2.2.3
+      rollup: 4.60.2
 
   '@napi-rs/nice-android-arm-eabi@1.1.1':
     optional: true
@@ -9539,6 +10245,68 @@ snapshots:
       - vue-tsc
       - yaml
 
+  '@nuxtjs/i18n@10.3.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)(@vue/compiler-dom@3.5.32)(db0@0.3.4(@electric-sql/pglite@0.4.1)(mysql2@3.15.3))(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.32(typescript@5.9.3))':
+    dependencies:
+      '@intlify/core': 11.4.0
+      '@intlify/h3': 0.7.4
+      '@intlify/shared': 11.4.0
+      '@intlify/unplugin-vue-i18n': 11.1.2(@vue/compiler-dom@3.5.32)(eslint@9.39.1(jiti@2.6.1))(rollup@4.60.2)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vue-i18n@11.4.0(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+      '@intlify/utils': 0.14.1
+      '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.60.2)
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@rollup/plugin-yaml': 4.1.2(rollup@4.60.2)
+      '@vue/compiler-sfc': 3.5.32
+      defu: 6.1.7
+      devalue: 5.7.1
+      h3: 1.15.11
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      nuxt-define: 1.0.0
+      oxc-parser: 0.112.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)
+      oxc-transform: 0.112.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)
+      oxc-walker: 0.7.0(oxc-parser@0.112.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1))
+      pathe: 2.0.3
+      ufo: 1.6.3
+      unplugin: 2.3.11
+      unrouting: 0.1.7
+      unstorage: 1.17.5(db0@0.3.4(@electric-sql/pglite@0.4.1)(mysql2@3.15.3))(ioredis@5.10.1)
+      vue-i18n: 11.4.0(vue@3.5.32(typescript@5.9.3))
+      vue-router: 5.0.4(@vue/compiler-sfc@3.5.32)(vue@3.5.32(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vue/compiler-dom'
+      - aws4fetch
+      - db0
+      - eslint
+      - idb-keyval
+      - ioredis
+      - magicast
+      - petite-vue-i18n
+      - pinia
+      - rollup
+      - supports-color
+      - typescript
+      - uploadthing
+      - vite
+      - vue
+
   '@nuxtjs/tailwindcss@6.14.0(magicast@0.5.2)(yaml@2.8.3)':
     dependencies:
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
@@ -9630,52 +10398,108 @@ snapshots:
   '@oxc-minify/binding-win32-x64-msvc@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-android-arm-eabi@0.112.0':
+    optional: true
+
   '@oxc-parser/binding-android-arm-eabi@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.112.0':
     optional: true
 
   '@oxc-parser/binding-android-arm64@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-darwin-arm64@0.112.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-arm64@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.112.0':
     optional: true
 
   '@oxc-parser/binding-darwin-x64@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-freebsd-x64@0.112.0':
+    optional: true
+
   '@oxc-parser/binding-freebsd-x64@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.112.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-gnueabihf@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.112.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-musleabihf@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.112.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-musl@0.112.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-musl@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.112.0':
     optional: true
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.112.0':
+    optional: true
+
   '@oxc-parser/binding-linux-riscv64-gnu@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.112.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-musl@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.112.0':
+    optional: true
+
   '@oxc-parser/binding-linux-s390x-gnu@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.112.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-musl@0.112.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-musl@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-openharmony-arm64@0.112.0':
+    optional: true
+
   '@oxc-parser/binding-openharmony-arm64@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.112.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.117.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)':
@@ -9686,63 +10510,130 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@oxc-parser/binding-win32-arm64-msvc@0.112.0':
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.112.0':
     optional: true
 
   '@oxc-parser/binding-win32-ia32-msvc@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-win32-x64-msvc@0.112.0':
+    optional: true
+
   '@oxc-parser/binding-win32-x64-msvc@0.117.0':
     optional: true
 
+  '@oxc-project/types@0.112.0': {}
+
   '@oxc-project/types@0.117.0': {}
 
+  '@oxc-transform/binding-android-arm-eabi@0.112.0':
+    optional: true
+
   '@oxc-transform/binding-android-arm-eabi@0.117.0':
+    optional: true
+
+  '@oxc-transform/binding-android-arm64@0.112.0':
     optional: true
 
   '@oxc-transform/binding-android-arm64@0.117.0':
     optional: true
 
+  '@oxc-transform/binding-darwin-arm64@0.112.0':
+    optional: true
+
   '@oxc-transform/binding-darwin-arm64@0.117.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-x64@0.112.0':
     optional: true
 
   '@oxc-transform/binding-darwin-x64@0.117.0':
     optional: true
 
+  '@oxc-transform/binding-freebsd-x64@0.112.0':
+    optional: true
+
   '@oxc-transform/binding-freebsd-x64@0.117.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.112.0':
     optional: true
 
   '@oxc-transform/binding-linux-arm-gnueabihf@0.117.0':
     optional: true
 
+  '@oxc-transform/binding-linux-arm-musleabihf@0.112.0':
+    optional: true
+
   '@oxc-transform/binding-linux-arm-musleabihf@0.117.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.112.0':
     optional: true
 
   '@oxc-transform/binding-linux-arm64-gnu@0.117.0':
     optional: true
 
+  '@oxc-transform/binding-linux-arm64-musl@0.112.0':
+    optional: true
+
   '@oxc-transform/binding-linux-arm64-musl@0.117.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-ppc64-gnu@0.112.0':
     optional: true
 
   '@oxc-transform/binding-linux-ppc64-gnu@0.117.0':
     optional: true
 
+  '@oxc-transform/binding-linux-riscv64-gnu@0.112.0':
+    optional: true
+
   '@oxc-transform/binding-linux-riscv64-gnu@0.117.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.112.0':
     optional: true
 
   '@oxc-transform/binding-linux-riscv64-musl@0.117.0':
     optional: true
 
+  '@oxc-transform/binding-linux-s390x-gnu@0.112.0':
+    optional: true
+
   '@oxc-transform/binding-linux-s390x-gnu@0.117.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-gnu@0.112.0':
     optional: true
 
   '@oxc-transform/binding-linux-x64-gnu@0.117.0':
     optional: true
 
+  '@oxc-transform/binding-linux-x64-musl@0.112.0':
+    optional: true
+
   '@oxc-transform/binding-linux-x64-musl@0.117.0':
     optional: true
 
+  '@oxc-transform/binding-openharmony-arm64@0.112.0':
+    optional: true
+
   '@oxc-transform/binding-openharmony-arm64@0.117.0':
+    optional: true
+
+  '@oxc-transform/binding-wasm32-wasi@0.112.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@oxc-transform/binding-wasm32-wasi@0.117.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)':
@@ -9753,10 +10644,19 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@oxc-transform/binding-win32-arm64-msvc@0.112.0':
+    optional: true
+
   '@oxc-transform/binding-win32-arm64-msvc@0.117.0':
     optional: true
 
+  '@oxc-transform/binding-win32-ia32-msvc@0.112.0':
+    optional: true
+
   '@oxc-transform/binding-win32-ia32-msvc@0.117.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-x64-msvc@0.112.0':
     optional: true
 
   '@oxc-transform/binding-win32-x64-msvc@0.117.0':
@@ -10063,6 +10963,14 @@ snapshots:
       serialize-javascript: 7.0.5
       smob: 1.6.1
       terser: 5.46.1
+    optionalDependencies:
+      rollup: 4.60.2
+
+  '@rollup/plugin-yaml@4.1.2(rollup@4.60.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      js-yaml: 4.1.1
+      tosource: 2.0.0-alpha.3
     optionalDependencies:
       rollup: 4.60.2
 
@@ -10513,6 +11421,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.50.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.50.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.50.0':
     dependencies:
       '@typescript-eslint/types': 8.50.0
@@ -10521,6 +11438,10 @@ snapshots:
   '@typescript-eslint/tsconfig-utils@8.50.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
+
+  '@typescript-eslint/tsconfig-utils@8.50.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@typescript-eslint/type-utils@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)':
     dependencies:
@@ -10544,10 +11465,25 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.50.0
       debug: 4.4.3
       minimatch: 9.0.5
-      semver: 7.7.3
-      tinyglobby: 0.2.15
+      semver: 7.7.4
+      tinyglobby: 0.2.16
       ts-api-utils: 2.1.0(typescript@5.9.2)
       typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.50.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.50.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.50.0
+      '@typescript-eslint/visitor-keys': 8.50.0
+      debug: 4.4.3
+      minimatch: 9.0.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10794,6 +11730,8 @@ snapshots:
     dependencies:
       '@vue/compiler-dom': 3.5.32
       '@vue/shared': 3.5.32
+
+  '@vue/devtools-api@6.6.4': {}
 
   '@vue/devtools-api@8.1.1':
     dependencies:
@@ -11060,6 +11998,10 @@ snapshots:
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
 
   acorn-walk@8.3.5:
     dependencies:
@@ -12205,6 +13147,35 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -12243,6 +13214,14 @@ snapshots:
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
 
   eslint-config-prettier@10.1.1(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
@@ -12352,6 +13331,12 @@ snapshots:
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
+
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 3.4.3
 
   esprima@4.0.1: {}
 
@@ -13647,6 +14632,13 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-eslint-parser@2.4.2:
+    dependencies:
+      acorn: 8.16.0
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      semver: 7.7.4
+
   jsonc-parser@3.3.1: {}
 
   jsonfile@6.2.0:
@@ -14219,6 +15211,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  nuxt-define@1.0.0: {}
+
   nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@electric-sql/pglite@0.4.1)(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)(@parcel/watcher@2.5.6)(@types/node@24.12.2)(@vue/compiler-sfc@3.5.32)(cac@6.7.14)(commander@11.1.0)(db0@0.3.4(@electric-sql/pglite@0.4.1)(mysql2@3.15.3))(eslint@9.39.1(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.15.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.2))(rollup@4.60.2)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
@@ -14504,6 +15498,34 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  oxc-parser@0.112.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1):
+    dependencies:
+      '@oxc-project/types': 0.112.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.112.0
+      '@oxc-parser/binding-android-arm64': 0.112.0
+      '@oxc-parser/binding-darwin-arm64': 0.112.0
+      '@oxc-parser/binding-darwin-x64': 0.112.0
+      '@oxc-parser/binding-freebsd-x64': 0.112.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.112.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.112.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.112.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.112.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.112.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.112.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.112.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.112.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.112.0
+      '@oxc-parser/binding-linux-x64-musl': 0.112.0
+      '@oxc-parser/binding-openharmony-arm64': 0.112.0
+      '@oxc-parser/binding-wasm32-wasi': 0.112.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)
+      '@oxc-parser/binding-win32-arm64-msvc': 0.112.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.112.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.112.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   oxc-parser@0.117.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1):
     dependencies:
       '@oxc-project/types': 0.117.0
@@ -14528,6 +15550,32 @@ snapshots:
       '@oxc-parser/binding-win32-arm64-msvc': 0.117.0
       '@oxc-parser/binding-win32-ia32-msvc': 0.117.0
       '@oxc-parser/binding-win32-x64-msvc': 0.117.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  oxc-transform@0.112.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1):
+    optionalDependencies:
+      '@oxc-transform/binding-android-arm-eabi': 0.112.0
+      '@oxc-transform/binding-android-arm64': 0.112.0
+      '@oxc-transform/binding-darwin-arm64': 0.112.0
+      '@oxc-transform/binding-darwin-x64': 0.112.0
+      '@oxc-transform/binding-freebsd-x64': 0.112.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.112.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.112.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.112.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.112.0
+      '@oxc-transform/binding-linux-ppc64-gnu': 0.112.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.112.0
+      '@oxc-transform/binding-linux-riscv64-musl': 0.112.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.112.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.112.0
+      '@oxc-transform/binding-linux-x64-musl': 0.112.0
+      '@oxc-transform/binding-openharmony-arm64': 0.112.0
+      '@oxc-transform/binding-wasm32-wasi': 0.112.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)
+      '@oxc-transform/binding-win32-arm64-msvc': 0.112.0
+      '@oxc-transform/binding-win32-ia32-msvc': 0.112.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.112.0
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -14557,6 +15605,11 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  oxc-walker@0.7.0(oxc-parser@0.112.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)):
+    dependencies:
+      magic-regexp: 0.10.0
+      oxc-parser: 0.112.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)
 
   oxc-walker@0.7.0(oxc-parser@0.117.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.7.1)):
     dependencies:
@@ -15935,6 +16988,8 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  tosource@2.0.0-alpha.3: {}
+
   totalist@3.0.1: {}
 
   tr46@0.0.3: {}
@@ -15942,6 +16997,10 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
+
+  ts-api-utils@2.1.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
 
   ts-interface-checker@0.1.13: {}
 
@@ -16446,6 +17505,14 @@ snapshots:
 
   vue-devtools-stub@0.1.0: {}
 
+  vue-i18n@11.4.0(vue@3.5.32(typescript@5.9.3)):
+    dependencies:
+      '@intlify/core-base': 11.4.0
+      '@intlify/devtools-types': 11.4.0
+      '@intlify/shared': 11.4.0
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.32(typescript@5.9.3)
+
   vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 7.29.1
@@ -16649,6 +17716,11 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
+
+  yaml-eslint-parser@1.3.2:
+    dependencies:
+      eslint-visitor-keys: 3.4.3
+      yaml: 2.8.3
 
   yaml@2.8.3: {}
 


### PR DESCRIPTION
## 🎯 Description
Implemented a comprehensive Internationalization (i18n) layer across the entire stack, supporting **English (en-GB)**, **Portuguese (pt-BR)**, and **Spanish (es-ES)**.

## 🛠 Changes
- **Infrastructure:** Integrated `@nuxtjs/i18n` with a lazy-loading strategy to optimize bundle size.
- **UI/UX:** Created a professional, accessible Language Selector (Select Box) for both Login and Dashboard.
- **Persistence:** Refactored search and pagination logic to ensure state (query params) is preserved during locale switches.
- **Architecture:** 
  - Updated `auth.global.ts` middleware to be locale-aware.
  - Implemented the **Reactive Getter Pattern** for Chart.js labels to update instantly on language change.
  - Synchronized `localePath` across all internal navigation (including Logout redirects).
- **Localization:** Integrated the native `Intl` API for culture-specific date and data formatting.

## 💡 Architectural Notes
- **Strategy:** Used `prefix_except_default` for SEO optimization and clear route structure.
- **Resilience:** Solved the "state loss" edge case where search terms were cleared upon navigation between localized routes.
- **Scalability:** Translation keys are organized by module (`users`, `profile`, `charts`), making it easy to add new languages.

## 🧪 How to test
1. Run the app and switch languages on the **Login Page**.
2. Log in and perform a search in the **User Management** page.
3. Switch languages while a search term is active and verify the term and results persist.
4. Go to **Profile** and **Dashboard** to verify that dates, charts, and navigation remain in the selected locale.
